### PR TITLE
Fix for using @view with a UserDict

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2084,7 +2084,7 @@ def view(tpl_name, **defaults):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             result = func(*args, **kwargs)
-            if isinstance(result, (dict, UserDict)):
+            if isinstance(result, (dict, DictMixin)):
                 tplvars = defaults.copy()
                 tplvars.update(result)
                 return template(tpl_name, **tplvars)


### PR DESCRIPTION
Hi Marcel,

My app is currently running on bottle 0.8.0 and returns a UserDict subclass to the @view decorator. I upgraded to bottle 0.8.3 today and that functionality broke. After adding UserDict to the isinstance check in @view, everything looks and works great.

Is there any way you could also drop this into 0.8.4 if you do another bugfix release?

Regards,
Brandon Gilmore
