### PR TITLE
Formarcel

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1152,7 +1152,9 @@ class WSGIFileWrapper(object):
 
 def dict2json(d):
     response.content_type = 'application/json'
-    return json_dumps(d)
+    result = json_dumps(d)
+    response.content_length = len(result)
+    return result
 
 
 def abort(code=500, text='Unknown Error: Application stopped.'):

--- a/test/test_outputfilter.py
+++ b/test/test_outputfilter.py
@@ -69,10 +69,20 @@ class TestOutputFilter(ServerTestBase):
     def test_json(self):
         self.app.route('/')(lambda: {'a': 1})
         if bottle.json_dumps:
-            self.assertBody(bottle.json_dumps({'a': 1}))
+            res = bottle.json_dumps({'a': 1})
+            self.assertBody(res)
             self.assertHeader('Content-Type','application/json')
+            self.assertHeader('Content-Length',str(len(res)))
         else:
             print "Warning: No json module installed."
+
+    def test_json_emptydict(self):
+        if bottle.json_dumps:
+            res = bottle.json_dumps({})
+            self.app.route('/')(lambda: {})
+            self.assertBody(res)
+            self.assertHeader('Content-Type','application/json')
+            self.assertHeader('Content-Length',str(len(res)))
 
     def test_custom(self):
         self.app.route('/')(lambda: {'a': 1, 'b': 2})


### PR DESCRIPTION
This adds Content-Length for dict2json output, enabling HTTP/1.1 persistent connections.

A similar patch can be written easily for the plugins2 branch, tell me if you are interested in me doing it.

Regards
Santiago
