### PR TITLE
Fix syntax error in tests

### DIFF
--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -164,7 +164,7 @@ class TestPluginAPI(tools.ServerTestBase):
     def test_callable(self):
         def plugin(func):
             def wrapper(*a, **ka):
-                return func(*a, test='me', **ka) + '; tail'
+                return func(test='me', *a, **ka) + '; tail'
             return wrapper
         self.app.install(plugin)
         self.assertBody('test:me; tail', '/')
@@ -174,7 +174,7 @@ class TestPluginAPI(tools.ServerTestBase):
         class Plugin(object):
             def apply(self, func, cfg):
                 def wrapper(*a, **ka):
-                    return func(*a, test=cfg['config']['test'], **ka) + '; tail'
+                    return func(test=cfg['config']['test'], *a, **ka) + '; tail'
                 return wrapper
             def __call__(self, func):
                 raise AssertionError("Plugins must not be called "\


### PR DESCRIPTION
I think Python 2.5 prefers named parameters, then the _args and *_kwargs, when calling a function.

```
Traceback (most recent call last):
File "/Users/scollins/Programming/bottle/test/testall.py", line 38, in <module>
suite = unittest.defaultTestLoader.loadTestsFromNames(test_names)
File "/System/Library/Frameworks/Python.framework/Versions/2.5/lib/python2.5/unittest.py", line 565, in loadTestsFromNames
suites = [self.loadTestsFromName(name, module) for name in names]
File "/System/Library/Frameworks/Python.framework/Versions/2.5/lib/python2.5/unittest.py", line 533, in loadTestsFromName
module = __import__('.'.join(parts_copy))
File "/Users/scollins/Programming/bottle/test/test_plugins.py", line 167
return func(*a, test='me', **ka) + '; tail'
                   ^
```
