### PR TITLE
inline argument to static_file()

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1359,7 +1359,7 @@ def send_file(*a, **k): #BC 0.6.4
     raise static_file(*a, **k)
 
 
-def static_file(filename, root, guessmime=True, mimetype=None, download=False):
+def static_file(filename, root, guessmime=True, mimetype=None, download=False, inline=False):
     """ Opens a file in a safe way and returns a HTTPError object with status
         code 200, 305, 401 or 404. Sets Content-Type, Content-Length and
         Last-Modified header. Obeys If-Modified-Since header and HEAD requests.
@@ -1382,8 +1382,12 @@ def static_file(filename, root, guessmime=True, mimetype=None, download=False):
 
     if download == True:
         download = os.path.basename(filename)
+    if inline == True:
+        inline = os.path.basename(filename)
     if download:
         header['Content-Disposition'] = 'attachment; filename="%s"' % download
+    elif inline:
+        header['Content-Disposition'] = 'inline; filename="%s"' % inline
 
     stats = os.stat(filename)
     lm = time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(stats.st_mtime))


### PR DESCRIPTION
I want the files that I serve via static_file() to open inside the browser (i.e. not force a download), however, if the user chooses to save the file, I want to set the default filename. The way to achieve this is by setting Content-Disposition header to "inline; filename=...". The commit adds inline argument to static_file(), which sets the header appropriately.
