### PR TITLE
Fix broken link

### DIFF
--- a/docs/tutorial_app.rst
+++ b/docs/tutorial_app.rst
@@ -11,7 +11,7 @@
 .. _Flup: http://trac.saddi.com/flup
 .. _Paste: http://pythonpaste.org/
 .. _Apache: http://www.apache.org
-.. _`Bottle documentation`: http://github.com/defnull/bottle/blob/master/docs/docs.md
+.. _`Bottle documentation`: http://github.com/defnull/bottle/blob/master/docs/tutorial.rst
 .. _`mod_wsgi`: http://code.google.com/p/modwsgi/
 .. _`json`: http://www.json.org
 


### PR DESCRIPTION
Fix broken link. It may or may not be the right new link, I couldn't find any move operation, after docs.md disappeared post- aacef68872b26dcda893cdefb739b763a0a802a1
