### PR TITLE
JSONPlugin returns content-type application/json when JSON serialization fails, should return text/html

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1306,8 +1306,11 @@ class JSONPlugin(object):
         def wrapper(*a, **ka):
             rv = callback(*a, **ka)
             if isinstance(rv, dict):
+                #Attempt to serialize, raises exception on failure
+                json = dumps(rv)
+                #Set content type only if serialization succesful
                 response.content_type = 'application/json'
-                return dumps(rv)
+                return json
             return rv
         return wrapper
 

--- a/test/test_outputfilter.py
+++ b/test/test_outputfilter.py
@@ -74,6 +74,18 @@ class TestOutputFilter(ServerTestBase):
         except ImportError:
             warn("Skipping JSON tests.")
 
+    def test_json_serialization_error(self):
+        """
+        Verify that 500 errors serializing dictionaries don't return
+        content-type application/json
+        """
+        self.app.route('/')(lambda: {'a': set()})
+        try:
+            self.assertStatus(500)
+            self.assertHeader('Content-Type','text/html; charset=UTF-8')
+        except ImportError:
+            warn("Skipping JSON tests.")
+
     def test_generator_callback(self):
         @self.app.route('/')
         def test():


### PR DESCRIPTION
This commit fixes the issue, and makes the 500 error page readable in the case where json serialization raises an exception. Test case included.
