### PR TITLE
Fix PEP-8 violation in JSONPlugin by renaming 'json' to 'json_result', to avoid name clash with json module in stdlib.

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1307,10 +1307,10 @@ class JSONPlugin(object):
             rv = callback(*a, **ka)
             if isinstance(rv, dict):
                 #Attempt to serialize, raises exception on failure
-                json = dumps(rv)
+                json_response = dumps(rv)
                 #Set content type only if serialization succesful
                 response.content_type = 'application/json'
-                return json
+                return json_response
             return rv
         return wrapper
 


### PR DESCRIPTION
iurisilvio pointed out that in 08e88007a2da46053788a33fbcef6f39452b4176 the variable name 'json' is not PEP-8 compliant, since there is a json module in the stdlib. He is correct, if you insist on PEP-8 compliance then this commit fixes the issue.
