### PR TITLE
Add **kwargs to SimpleTemplate.prepare to fix #203

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2459,7 +2459,7 @@ class SimpleTemplate(BaseTemplate):
              |\#.*                        # Comments
             )''', re.VERBOSE)
 
-    def prepare(self, escape_func=html_escape, noescape=False):
+    def prepare(self, escape_func=html_escape, noescape=False, **kwargs):
         self.cache = {}
         enc = self.encoding
         self._str = lambda x: touni(x, enc)

--- a/test/test_stpl.py
+++ b/test/test_stpl.py
@@ -214,6 +214,10 @@ class TestSimpleTemplate(unittest.TestCase):
             return dict(var='middle')
         self.assertEqual(u'start middle end', test())
 
+    def test_global_config(self):
+        SimpleTemplate.global_config('meh', 1)
+        t = SimpleTemplate(u'anything')
+        self.assertEqual(u'anything', t.render())
 
 if __name__ == '__main__': #pragma: no cover
     unittest.main()


### PR DESCRIPTION
A solution to #203, with a regression test.

Another solution is don't send kwargs to SimpleTemplate, but I guess it is more complicated than that.
