### PR TITLE
Fixing GunicornServer

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2079,7 +2079,7 @@ class GunicornServer(ServerAdapter):
         config = {'bind': "%s:%d" % (self.host, int(self.port)), 'workers': 4}
 
         class GunicornApplication(Application):
-            def init(_self, parser, opts, args):
+            def init(self, parser, opts, args):
                 return config
 
             def load(self):


### PR DESCRIPTION
GunicornServer was broken because of Bottle and Gunicorn interface changes.

I tested this implementation running Bottle with Gunicorn 0.8.0 and Gunicorn last release (0.13.2). It works fine.

Gunicorn 0.9 has more than one year and more than 10 releases after that, compatible with new implementation. Probably, we can just drop support for Gunicorn<0.9.
