### PR TITLE
workaround for bug in functools.update_wrapper for bound methods.

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -476,7 +476,7 @@ class Route(object):
                     callback = plugin(callback)
             except RouteReset: # Try again with changed configuration.
                 return self._make_callback()
-            if type(callback) is types.FunctionType:
+            if isinstance(callback, types.FunctionType):
               functools.update_wrapper(callback, self.callback)
         return callback
 


### PR DESCRIPTION
arguably a fix for https://github.com/defnull/bottle/issues/223 though there are other places where functools.update_wrapper is called.  this is sufficient for my needs.
