### PR TITLE
Fix typo in documentation (Ignore trailing slashes)

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -99,7 +99,7 @@ or add a WSGI middleware that strips trailing slashes from all URLs::
     
     app = bottle.app()
     myapp = StripPathMiddleware(app)
-    bottle.run(app=appmy)
+    bottle.run(app=myapp)
 
 .. rubric:: Footnotes
 


### PR DESCRIPTION
Just a quick fix of a typo "appmy" was replaced by "myapp" ;)
