### PR TITLE
SimpleTemplate: %rebase does not cache base_template 

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2658,10 +2658,9 @@ class SimpleTemplate(BaseTemplate):
         eval(self.co, env)
         if '_rebase' in env:
             subtpl, rargs = env['_rebase']
-            subtpl = self.__class__(name=subtpl, lookup=self.lookup)
             rargs['_base'] = _stdout[:] #copy stdout
             del _stdout[:] # clear stdout
-            return subtpl.execute(_stdout, rargs)
+            return self.subtemplate(subtpl,_stdout,rargs)
         return env
 
     def render(self, *args, **kwargs):


### PR DESCRIPTION
(Hopefully sending the right branch this time)

I noticed that when you use %rebase base_template in SimpleTemplate a new instance of base_template is created for every call and not saved in the cache (which the subtemplate function does for %include sub_template). This is clearly somewhat inefficient & I attach a diff which fixes this (implementing %rebase using the existing subtemplate function).

(I am not too familiar with Git pull-requests so hope this is the right thing to do)
