### PR TITLE
view decorator and plugin keywords issue.

### DIFF
--- a/test/test_wsgi.py
+++ b/test/test_wsgi.py
@@ -282,6 +282,15 @@ class TestDecorators(ServerTestBase):
         self.assertInBody('401: Unauthorized', '/tpl')
         self.assertStatus(401, '/tpl')
 
+    def test_view_plugin(self):
+        """ WSGI: Test view-decorator with plugin keyword."""
+        @bottle.route('/tpl')
+        @bottle.view('stpl_simple')
+        def test(plugin_keyword):
+            return dict(var='var')
+        self.assertInBody('start var end', '/tpl')
+        self.assertStatus(200, '/tpl')
+
     def test_validate(self):
         """ WSGI: Test validate-decorator"""
         @bottle.route('/:var')


### PR DESCRIPTION
I'm trying to mix the `@view` decorator with the [bottle-sqlalchemy plugin](https://github.com/iurisilvio/bottle-sqlalchemy/), more or less the same as the attached unit test.

This unit test crash with:
`TypeError: test() takes exactly 1 argument (0 given)`
