### PR TITLE
Python3 Cookie Encode/Decode Error

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1847,6 +1847,7 @@ def _lscmp(a, b):
 
 def cookie_encode(data, key):
     ''' Encode and sign a pickle-able object. Return a (byte) string '''
+    key = key.encode()
     msg = base64.b64encode(pickle.dumps(data, -1))
     sig = base64.b64encode(hmac.new(key, msg).digest())
     return tob('!') + sig + tob('?') + msg
@@ -1855,6 +1856,7 @@ def cookie_encode(data, key):
 def cookie_decode(data, key):
     ''' Verify and decode an encoded string. Return an object or None.'''
     data = tob(data)
+    key = key.encode()
     if cookie_is_encoded(data):
         sig, msg = data.split(tob('?'), 1)
         if _lscmp(sig[1:], base64.b64encode(hmac.new(key, msg).digest())):


### PR DESCRIPTION
After running 2to3, bottle.py would fail to encode secure cookies, raising the following type error and issuing an HTTP 500:

```
TypeError: expected bytes, but got 'str'
```

To fix this, I simply encoded the key in both cookie_encode and cookie_decode. The bug has been marked as "wontfix" in the Python Standard Library, per issue 5285: http://bugs.python.org/issue5285

Also fixes the same issue in Python 2.6 and is backwards compatible with 2.5, as noted above.
