### PR TITLE
add tox.ini in order to easily test with multiple python versions

### DIFF
--- a/test/testall.py
+++ b/test/testall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+envlist = py25-empty,py26,py27,py32,py27-most
+
+[testenv]
+deps=Mako
+     jinja2
+commands={envpython} test/testall.py
+sitepackages=False
+
+[testenv:py25-empty]
+basepython=python2.5
+deps=simplejson
+
+[testenv:py27-most]
+basepython=python2.7
+deps=Mako
+     jinja2
+     eventlet
+     cherrypy
+     paste
+     twisted
+     tornado


### PR DESCRIPTION
tox allows running tests for multiple python versions with a different
set of installed packages. To try it, run:

tox -e py25,py27-most

The default is to test with python 2.5, 2.6, 2.7, 3.2. These must be
installed on the machine.

tox can be found here: http://pypi.python.org/pypi/tox
