### PR TITLE
Allow to use 'quiet' arg to disable eventletserver output

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2299,7 +2299,6 @@ class GunicornServer(ServerAdapter):
 
 class EventletServer(ServerAdapter):
     """ Untested """
-    quiet = False
     def run(self, handler):
         from eventlet import wsgi, listen
         try:


### PR DESCRIPTION
pass `quiet = True` to `bottle.run` to disable annoying eventlet access log. 
