### PR TITLE
Encoding definition improved in SimpleTemplate

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2837,7 +2837,7 @@ class SimpleTemplate(BaseTemplate):
                         else unicode(line, encoding=self.encoding)
             sline = line.lstrip()
             if lineno <= 2:
-                m = re.search(r"%.*coding[:=]\s*([-\w.]+)", line)
+                m = re.search(r"^%\s*#.*coding[:=]\s*([-\w.]+)", line.lstrip())
                 if m: self.encoding = m.group(1)
                 if m: line = line.replace('coding','coding (removed)')
             if sline and sline[0] == '%' and sline[:2] != '%%':

--- a/test/test_stpl.py
+++ b/test/test_stpl.py
@@ -205,6 +205,11 @@ class TestSimpleTemplate(unittest.TestCase):
         self.assertEqual(touni('\n\nöäü?@€'), t.render())
         self.assertEqual(t.encoding, 'utf8')
 
+    def test_coding_stress(self):
+        self.assertRenders('%a=1\n%coding=a\nok', 'ok')
+        self.assertRenders('a %coding:b', 'a %coding:b')
+        self.assertRenders(' % #coding:utf-8', '')
+
     def test_template_shortcut(self):
         result = template('start {{var}} end', var='middle')
         self.assertEqual(touni('start middle end'), result)


### PR DESCRIPTION
SimpleTemplate crashed when I did it:

```
% a=1
% coding=a
```

This code is useless and probably nobody else will found this bug, I used the word "coding" by accident.

After that, I found the regex to parse this encoding and created some tests to break it in other improbable ways.
