### PR TITLE
Enhanced example using @error(404)

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -257,6 +257,7 @@ Error Pages
 
 If anything goes wrong, Bottle displays an informative but fairly boring error page. You can override the default for a specific HTTP status code with the :func:`error` decorator::
 
+  from bottle import error
   @error(404)
   def error404(error):
       return 'Nothing here, sorry'


### PR DESCRIPTION
Hello!
I added the import line in the `@error(404)` tutorial example.
This way the tutorial it's more complete.

Although I don't know how you're managing the http://bottlepy.org website, if it gets it's contents automatically from these files or not so they stay in sync. 
