### PR TITLE
template export it's namespace to subtemplate

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3008,14 +3008,14 @@ class SimpleTemplate(BaseTemplate):
                '_escape': self._escape, 'get': env.get,
                'setdefault': env.setdefault, 'defined': env.__contains__})
         env.update(kwargs)
-        if self.settings['export_env']:
+        if 'export_env' in self.settings:
             env["_args"] = kwargs
         eval(self.co, env)
         if '_rebase' in env:
             subtpl, rargs = env['_rebase']
             rargs['_base'] = _stdout[:] #copy stdout
             del _stdout[:] # clear stdout
-            pargs = kwargs if self.settings['export_env'] else {}
+            pargs = kwargs if 'export_env' in self.settings else {}
             return self.subtemplate(subtpl, _stdout, pargs, rargs)
         return env
 


### PR DESCRIPTION
sometimes It's convenient for export current namespace when rebase or include.

explicit set the option `bottle.SimpleTemplate.settings['export_env']` to `True` to enable this behavior.

subtemplate can overide the parent's namespace if they both defined same argument.

current this option is global for whole rendering process. The behavior can't change in subtemplate rendering.
