### PR TITLE
(#307) If 'gevent' and quite=True, suppress output

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2453,7 +2453,6 @@ class GeventServer(ServerAdapter):
           issues: No streaming, no pipelining, no SSL.
     """
     def run(self, handler):
-        print self.options
         from gevent import wsgi as wsgi_fast, pywsgi, monkey, local
         if self.options.get('monkey', True):
             if not threading.local is local.local: monkey.patch_all()


### PR DESCRIPTION
Issue #307:

When run(server='gevent', host='127.0.0.1', port=9999, quiet=True), bottle still log the request.

like
127.0.0.1 - - [2012-04-06 00:58:02] "POST / HTTP/1.1" 201 149 0.000999
