### PR TITLE
Fix exception when pickling FormsDict

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1765,6 +1765,9 @@ class FormsDict(MultiDict):
             return default
 
     def __getattr__(self, name, default=unicode()):
+        # Without this guard, pickle generates a cryptic TypeError:
+        if name.startswith('__') and name.endswith('__'):
+            return super(FormsDict, self).__getattr__(name)
         return self.getunicode(name, default=default)
 
 


### PR DESCRIPTION
Hello,

Currently, Python generates a very cryptic TypeError if you try to pickle a FormsDict object, because of the way `__getattr__` is implemented.  This is a 3-line bugfix for that problem.  It would be wonderful if you could incorporate this into the official version!

Thanks,
Ian
