### PR TITLE
POST arrays support

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1083,8 +1083,15 @@ class BaseRequest(object):
         else:
             fb = self.body
         data = cgi.FieldStorage(fp=fb, environ=safe_env, keep_blank_values=True)
-        for item in (data.list or [])[:self.MAX_PARAMS]:
-            post[item.name] = item if item.filename else item.value
+        for item_name in data.keys()[:self.MAX_PARAMS]:
+            item = data[item_name]
+            try:
+                post[item_name] = item if item.filename else item.value
+            except AttributeError: # item is list
+                value = data.getvalue(item_name)
+                if item_name.endswith('[]'):
+                    item_name = item_name[:-2]
+                post[item_name] = value
         return post
 
     @property


### PR DESCRIPTION
According to cgi module documentation FieldStorage item is list when POST contains multiple values with same parameter name. This change makes BaseRequest consume such parameters correctly and remove "[]" suffix from parameter name if present.
