### PR TITLE
A couple of minor documentation fixes

### DIFF
--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -99,8 +99,8 @@ In a second step, the request method is checked. If no exact match is found, and
 
 Here is an example where this might bite you::
 
-    @route('/:action/:name', method='GET')
-    @route('/save/:name', method='POST')
+    @route('/<action>/<name>', method='GET')
+    @route('/save/<name>', method='POST')
 
 The second route will never hit. Even POST requests don't arrive at the second route because the request method is checked in a separate step. The router stops at the first route which matches the request path, then checks for a valid request method, can't find one and raises a 405 error.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -176,7 +176,7 @@ You can add your own filters as well. See :doc:`Routing` for details.
 
 .. versionchanged:: 0.10
 
-The new rule syntax was introduced in **Bottle 0.10** to simplify some common use cases, but the old syntax still works and you can find lot code examples still using it. The differences are best described by example:
+The new rule syntax was introduced in **Bottle 0.10** to simplify some common use cases, but the old syntax still works and you can find a lot of code examples still using it. The differences are best described by example:
 
 =================== ====================
 Old Syntax          New Syntax


### PR DESCRIPTION
Hi -

I had an entire list of typos to fix in the documentation, but when I git cloned bottle I found that most of them had already been fixed.  So one small language fix in tutorial.rst and the Routing Order example in routing.rst was still using the legacy wildcard syntax; probably better to switch it to the new syntax?

Question: how could I have done this without forking the entire bottle tree on github?  That is, after cloning, editing, and committing I didn't know what to do with the patch file.  (Sorry if this is obvious, we use mercurial, so I'm not that familiar with git.)
