### PR TITLE
Updated url of logo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Bottle Web Framework
 ====================
 
-.. image:: http://bottlepy.org/bottle-logo.png
+.. image:: http://bottlepy.org/docs/dev/_static/logo_nav.png
   :alt: Bottle Logo
   :align: right
 


### PR DESCRIPTION
Hi,
The logo .png has moved but the README still refers to the old path.
