### PR TITLE
Update docs/stpl.rst

### DIFF
--- a/docs/stpl.rst
+++ b/docs/stpl.rst
@@ -32,10 +32,10 @@ Python is a very powerful language but its whitespace-aware syntax makes it diff
 
    The :class:`SimpleTemplate` syntax compiles directly to python bytecode and is executed on each :meth:`SimpleTemplate.render` call. Do not render untrusted templates! They may contain and execute harmful python code.
 
-Inline Statements
+Inline Expressions
 -----------------
 
-You already learned the use of the ``{{...}}`` statement from the "Hello World!" example above, but there is more: any python statement is allowed within the curly brackets as long as it returns a string or something that has a string representation::
+You already learned the use of the ``{{...}}`` syntax from the "Hello World!" example above, but there is more: any python expression is allowed within the curly brackets as long as it returns a string or something that has a string representation::
 
   >>> template('Hello {{name}}!', name='World')
   u'Hello World!'
@@ -44,7 +44,7 @@ You already learned the use of the ``{{...}}`` statement from the "Hello World!"
   >>> template('Hello {{name.title() if name else "stranger"}}!', name='mArC')
   u'Hello Marc!'
 
-The contained python statement is executed at render-time and has access to all keyword arguments passed to the :meth:`SimpleTemplate.render` method. HTML special characters are escaped automatically to prevent `XSS <http://en.wikipedia.org/wiki/Cross-Site_Scripting>`_ attacks. You can start the statement with an exclamation mark to disable escaping for that statement::
+The contained python expression is executed at render-time and has access to all keyword arguments passed to the :meth:`SimpleTemplate.render` method. HTML special characters are escaped automatically to prevent `XSS <http://en.wikipedia.org/wiki/Cross-Site_Scripting>`_ attacks. You can start the expression with an exclamation mark to disable escaping for that expression::
 
   >>> template('Hello {{name}}!', name='<b>World</b>')
   u'Hello &lt;b&gt;World&lt;/b&gt;!'


### PR DESCRIPTION
The name "Inline Statements" seems misleading. If the Python code has to "return a string or something that has a string representation", you can _never_ use a Python statement there, only a Python expression, since statements don't return anything. I suggest mimicking the Python nomenclature and calling them "Inline Expressions" instead.
