### PR TITLE
Don't truncate POST body.

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1056,7 +1056,7 @@ class BaseRequest(object):
         # We default to application/x-www-form-urlencoded for everything that
         # is not multipart and take the fast path (also: 3.1 workaround)
         if not self.content_type.startswith('multipart/'):
-            maxlen = max(0, min(self.content_length, self.MEMFILE_MAX))
+            maxlen = max(0, self.content_length)
             pairs = _parse_qsl(tonat(self.body.read(maxlen), 'latin1'))
             for key, value in pairs[:self.MAX_PARAMS]:
                 post[key] = value


### PR DESCRIPTION
BaseRequest._body() already uses MEMFILE_MAX to avoid memory exhaustion.

If this behavior was intentional, I'd suggest that this policy belongs in server config.
