### PR TITLE
Update HTTPResponse call when mounting apps

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -568,7 +568,7 @@ class Bottle(object):
                     return rs.body.append
                 body = app(request.environ, start_response)
                 body = itertools.chain(rs.body, body)
-                return HTTPResponse(body, rs.status_code, rs.headers)
+                return HTTPResponse(body, rs.status_code, **rs.headers)
             finally:
                 request.path_shift(-path_depth)
 


### PR DESCRIPTION
Applying it to release 0.11 to remove the warning described in #395. I'm not sure if this is the right way to do it (duplicating pull requests to make it to 0.11 branch and to master).
