### PR TITLE
@never_cache decorator

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2142,6 +2142,12 @@ def static_file(filename, root, mimetype='auto', download=False):
 
 
 
+def never_cache(func):
+    @functools.wraps(func)
+    def _wraps(*args, **kwargs):
+        response.set_header('Cache-Control', 'no-cache')
+        return func(*args, **kwargs)
+    return _wraps
 
 
 

--- a/test/test_outputfilter.py
+++ b/test/test_outputfilter.py
@@ -177,5 +177,17 @@ class TestOutputFilter(ServerTestBase):
         self.assertTrue('b=b' in c)
         self.assertTrue('c=c; Path=/' in c)
 
+    def test_never_cache(self):
+        """no-cache Headers"""
+        from bottle import never_cache
+
+        @self.app.route('/')
+        @never_cache
+        def test():
+            return 'hello'
+
+        self.assertHeader('Cache-Control','no-cache')
+
+
 if __name__ == '__main__': #pragma: no cover
     unittest.main()


### PR DESCRIPTION
I built API based on bottle,  communicate with flash client.

I found that It's more convenient  using a decorator to set no-cache than  write
`response.set_header` in all GET method functions.

So, I added the `never_cache` decorator, and tests

```
from bottle import never_cache

@app.get('PATH')
@never_cache
def my_func():
    return 'hello'
```
