### PR TITLE
Fix content-type header in mounted apps.

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -561,7 +561,7 @@ class Bottle(object):
         def mountpoint_wrapper():
             try:
                 request.path_shift(path_depth)
-                rs = HTTPResponse([])
+                rs = BaseResponse([])
                 def start_response(status, headerlist):
                     rs.status = status
                     for name, value in headerlist: rs.add_header(name, value)


### PR DESCRIPTION
The fix in 0.11.5 to update the mountpoint_wrapper introduced a bug where "Content-Type: text/html; charset=UTF-8" is added in all my responses even though I'm only sending json and already set the appropriate header. Changing it back fixes the problem.
