### PR TITLE
let start_response accept 3 arguments with beaker

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -562,7 +562,12 @@ class Bottle(object):
             try:
                 request.path_shift(path_depth)
                 rs = HTTPResponse([])
-                def start_response(status, headerlist):
+                def start_response(status, headerlist, exc_info=None):
+                    if exc_info:
+                        try:
+                            raise exc_info[0], exc_info[1], exc_info[2]
+                        finally:
+                            exc_info = None
                     rs.status = status
                     for name, value in headerlist: rs.add_header(name, value)
                     return rs.body.append


### PR DESCRIPTION
When a sub-app decorated by **beaker**, 

there will an error occurred.

Look at the diff.

the origin _start_response_ accept only **2** arguments,

But, beaker call the start_response with **3** arguments.

beaker code:       

``` python
        def session_start_response(status, headers, exc_info=None):              
            if session.accessed():                                               
                session.persist()                                                
                if session.__dict__['_headers']['set_cookie']:                   
                    cookie = session.__dict__['_headers']['cookie_out']          
                    if cookie:                                                   
                        headers.append(('Set-cookie', cookie))                   
            return start_response(status, headers, exc_info)                     
        return self.wrap_app(environ, session_start_response) 
```

Test code:

``` python
import bottle
from beaker.middleware import SessionMiddleware

app = bottle.Bottle()


SESSION_OPTS = {
    'session.type': 'file',
    'session.cookie_expires': 86400,
    'session.data_dir': './session',
    'session.auto': True
}

admin_app = bottle.Bottle()
admin_app_session = SessionMiddleware(admin_app, SESSION_OPTS)

@app.get('/')
def index():
    return 'index'

@admin_app.get('/')
def admin():
    return 'Admin'


app.mount('/admin', admin_app_session)
bottle.run(app, host='0.0.0.0')
```
