### PR TITLE
mount with segmented prefix

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -552,7 +552,11 @@ class Bottle(object):
             prefix, app = app, prefix
             depr('Parameter order of Bottle.mount() changed.') # 0.10
 
-        segments = [p for p in prefix.split('/') if p]
+        if hasattr(prefix,'__iter__'):
+            segments = [p for p in prefix if p]
+            prefix = '/' + '/'.join(prefix)
+        else:
+            segments = [p for p in prefix.split('/') if p]
         if not segments: raise ValueError('Empty path prefix.')
         path_depth = len(segments)
 

--- a/test/test_mount.py
+++ b/test/test_mount.py
@@ -20,7 +20,16 @@ class TestAppMounting(ServerTestBase):
         self.assertStatus(200, '/test/test/bar')
         self.assertBody('bar', '/test/test/bar')
 
-    def test_mount_meta(self):
+    def test_mount_segmented_prefix(self):
+        self.app.mount(['test',''], self.subapp)
+        self.assertStatus(404, '/')
+        self.assertStatus(404, '/test')
+        self.assertStatus(200, '/test/')
+        self.assertBody('foo', '/test/')
+        self.assertStatus(200, '/test/test/bar')
+        self.assertBody('bar', '/test/test/bar')
+
+        def test_mount_meta(self):
         self.app.mount('/test/', self.subapp)
         self.assertEqual(
             self.app.routes[0].config.mountpoint['prefix'],


### PR DESCRIPTION
try to support regex that contain '/' like -

```
app.mount(['<:re:admin[^/]*>'],subapp)
```
