### PR TITLE
Enhancements to hooks because after_request hooks are not called after abort() or exception

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1654,7 +1654,7 @@ class HooksPlugin(object):
     name = 'hooks'
     api  = 2
 
-    _names = 'before_request', 'after_request', 'app_reset'
+    _names = 'before_request', 'after_request', 'app_reset', 'if_exception', 'if_abort'
 
     def __init__(self):
         self.hooks = dict((name, []) for name in self._names)
@@ -1689,9 +1689,16 @@ class HooksPlugin(object):
         if self._empty(): return callback
         def wrapper(*a, **ka):
             self.trigger('before_request')
-            rv = callback(*a, **ka)
-            self.trigger('after_request', reversed=True)
-            return rv
+            try:
+              rv = callback(*a, **ka)
+            except Exception as e:
+              self.trigger('if_exception', reversed=True)
+              if isinstance(e, HTTPError):
+                self.trigger('if_abort', reversed=True)
+              raise
+            else:
+              self.trigger('after_request', reversed=True)
+              return rv
         return wrapper
 
 


### PR DESCRIPTION
I added hook types 'if_exception' and 'if_abort' because hooks defined via 'after_request' aren't called if an exception is raised in a request handler, or abort() is called in a request handler.

I'm not sure if the previous behavior is on purpose. I needed to call a hook after abort()/exception() so I made this change.

Would appreciate if you reviewed, cleaned up and merge this patch.

Thanks for your great work!
