### PR TITLE
static_file: add charset to content-type

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2202,7 +2202,7 @@ def _file_iter_range(fp, offset, bytes, maxread=1024*1024):
         yield part
 
 
-def static_file(filename, root, mimetype='auto', download=False):
+def static_file(filename, root, mimetype='auto', download=False, autocharset='UTF-8'):
     """ Open a file in a safe way and return :exc:`HTTPResponse` with status
         code 200, 305, 401 or 404. Set Content-Type, Content-Encoding,
         Content-Length and Last-Modified header. Obey If-Modified-Since header
@@ -2221,6 +2221,8 @@ def static_file(filename, root, mimetype='auto', download=False):
 
     if mimetype == 'auto':
         mimetype, encoding = mimetypes.guess_type(filename)
+        if autocharset and mimetype.startswith('text/'):
+            mimetype += '; charset=%s' % autocharset
         if mimetype: headers['Content-Type'] = mimetype
         if encoding: headers['Content-Encoding'] = encoding
     elif mimetype:


### PR DESCRIPTION
currently static_file serves content-type as 'text/html' without
providing a charset, which makes firefox bark with this in the error log:

> The character encoding of the HTML document was not declared. The document
> will render with garbled text in some browser configurations if the document
> contains characters from outside the US-ASCII range. The character encoding
> of the page must be declared in the document or in the transfer protocol.

this patch modifies static_file to add "charset=UTF-8" to all "text/..." mimetypes
in case the mimetype was not provided explicitly. The actual charset used
can be configured via 'autocharset' keyword argument.

Note: I have not actually tested this patch, as I use a stable version.
