### PR TITLE
Prefer to use simplejson if it is available

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -42,9 +42,9 @@ from datetime import date as datedate, datetime, timedelta
 from tempfile import TemporaryFile
 from traceback import format_exc, print_exc
 
-try: from json import dumps as json_dumps, loads as json_lds
+try: from simplejson import dumps as json_dumps, loads as json_lds
 except ImportError: # pragma: no cover
-    try: from simplejson import dumps as json_dumps, loads as json_lds
+    try: from json import dumps as json_dumps, loads as json_lds
     except ImportError:
         try: from django.utils.simplejson import dumps as json_dumps, loads as json_lds
         except ImportError:


### PR DESCRIPTION
I've seen simplejson outperform the standard json module at least on Python 2.7.

I figure it probably can't hurt to try to import simplejson first, if it is available, for the added performance boost. This will still fallback to the standard built-in Python json module if simplejson is not available.
