### PR TITLE
Route ordering similar to werkzeug

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -382,6 +382,7 @@ class Router(object):
 
     def _compile(self, method):
         all_rules = self.dyna_routes[method]
+        self._sort_routes(all_rules)
         comborules = self.dyna_regexes[method] = []
         maxgroups = self._MAX_GROUPS_PER_PATTERN
         for x in range(0, len(all_rules), maxgroups):
@@ -391,6 +392,21 @@ class Router(object):
             combined = re.compile(combined).match
             rules = [(target, getargs) for (_, _, target, getargs) in some]
             comborules.append((combined, rules))
+
+    def _sort_routes(self, rules):
+        def key(wholerule):
+            rule, flatpat, target, getargs = wholerule
+            builder = self.builder[rule]
+            weights = []
+            for part in builder:
+                if part[0] is None: #static part
+                    for subpart in part[1].split("/"):
+                        if subpart:
+                            weights.append((0, -len(subpart)))
+                else: # dynamic parts have less weight than dynamic
+                    weights.append((1, 1000))
+            return (-len(weights), weights)
+        rules.sort(key=key)        
 
     def build(self, _name, *anons, **query):
         ''' Build an URL by filling the wildcards in a rule. '''

--- a/bottle.py
+++ b/bottle.py
@@ -381,7 +381,7 @@ class Router(object):
         self._compile(method)
 
     def _compile(self, method):
-        all_rules = self.dyna_routes[method]
+        all_rules = [] + self.dyna_routes[method]
         self._sort_routes(all_rules)
         comborules = self.dyna_regexes[method] = []
         maxgroups = self._MAX_GROUPS_PER_PATTERN

--- a/test/test_router.py
+++ b/test/test_router.py
@@ -179,6 +179,14 @@ class TestRouter(unittest.TestCase):
         target, urlargs = self.match('/test/something/xxx.html', 'GET')
         self.assertEqual(target, 'c')
 
+    def test_ordering_override(self):
+        self.add_m([
+            ('/<path:path>', 'a', 'GET'),
+            ('/<path:path>', 'b', 'GET'),
+        ])
+        target, urlargs = self.match('/www', 'GET')
+        self.assertEqual(target, 'b')
+
     def test_ordering_post_r(self):
         self.test_ordering_post(True)
 


### PR DESCRIPTION
Since you merged my last pull request, whose main purpose was to ease implementation of route ordering based on any priority algorithm, I propose a sorting algorithm based on werkzeug's one.

The precise algorithm used by werkzeug is hard to find. But it still has some documentation in the code, in werkzeug.routing.Route.match_compare_key.

The ordering is the following:
- static routes always have top priority (that was already the case in bottle)
- for dynamic routes, the more complex it is the more priority it has
- for routes with the same complexity, it compares the different parts in the route from left to right. Static parts always have an higher priority. The only difference with werkzeug is that, in werkzeug, some type of dynamic patterns have more priority than others (ie: integer has more than path), but I didn't think it was really necessary to implement that.

Even if you don't like the idea to switch to an auto-ordering mode for routes, I think it would still be a good idea to implement it as an option in the Router class.
