### PR TITLE
Added 'fast' option to WSGIRefServer to disable reverse DNS look-ups.

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2637,7 +2637,18 @@ class FlupFCGIServer(ServerAdapter):
 class WSGIRefServer(ServerAdapter):
     def run(self, handler): # pragma: no cover
         from wsgiref.simple_server import make_server, WSGIRequestHandler
-        if self.quiet:
+        # disable Reverse DNS Lookups -> faster service ?
+        fast = self.options.pop('fast', False)
+        if fast and self.quiet:
+            class FastAndQuietHandler(WSGIRequestHandler):
+                def address_string(self): return self.client_address[0]
+                def log_request(*args, **kw): pass
+            self.options['handler_class'] = FastAndQuietHandler
+        elif fast:
+            class FastHandler(WSGIRequestHandler):
+                def address_string(self): return self.client_address[0]
+            self.options['handler_class'] = FastHandler
+        elif self.quiet:
             class QuietHandler(WSGIRequestHandler):
                 def log_request(*args, **kw): pass
             self.options['handler_class'] = QuietHandler


### PR DESCRIPTION
The default WSGIRefServer implementation performs a reverse DNS look-up for every log entry.  If rDNS is slow or down, this holds up every web serve - possibly as much as by the rDNS time-out of 5 to 10 seconds!

The following patch adds an option to easily disable rDNS look-ups and logging through the run() method, like so:

```
app = bottle.default_app()
bottle.run(host='0.0.0.0', port='80', app=app, fast=True)
```

This has proved very helpful for speeding up page serves for me.  I hope it proves helpful for others.
