### PR TITLE
Don't use super() for old-style classes

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2642,7 +2642,7 @@ class WSGIRefServer(ServerAdapter):
                 return self.client_address[0]
             def log_request(*args, **kw):
                 if not self.quiet:
-                    return super(FixedHandler, self).log_request(*args, **kw)
+                    return WSGIRequestHandler.log_request(*args, **kw)
         self.options['handler_class'] = FixedHandler
         srv = make_server(self.host, self.port, handler, **self.options)
         srv.serve_forever()


### PR DESCRIPTION
`super()` is for new-style classes only.
See http://docs.python.org/2/library/functions.html#super

Unpatched, the following exception is thrown on each request. After patching, requests are logged without throwing exceptions.

Note that other instances of `super()` may need to be replaced as well. I didn't check the others.

```
----------------------------------------
Exception happened during processing of request from ('127.0.0.1', 48746)
Traceback (most recent call last):
  File "/usr/lib/python2.7/SocketServer.py", line 295, in _handle_request_noblock
    self.process_request(request, client_address)
  File "/usr/lib/python2.7/SocketServer.py", line 321, in process_request
    self.finish_request(request, client_address)
  File "/usr/lib/python2.7/SocketServer.py", line 334, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python2.7/SocketServer.py", line 649, in __init__
    self.handle()
  File "/usr/lib/python2.7/wsgiref/simple_server.py", line 124, in handle
    handler.run(self.server.get_app())
  File "/usr/lib/python2.7/wsgiref/handlers.py", line 92, in run
    self.close()
  File "/usr/lib/python2.7/wsgiref/simple_server.py", line 33, in close
    self.status.split(' ',1)[0], self.bytes_sent
  File "/home/tylerl/bottle/bottle.py", line 2645, in log_request
    return super(FixedHandler, self).log_request(*args, **kw)
TypeError: must be type, not classobj
----------------------------------------
```
