### PR TITLE
Changing bottle to accept options for cherrypy server like numofthreads ...

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2651,7 +2651,9 @@ class WSGIRefServer(ServerAdapter):
 class CherryPyServer(ServerAdapter):
     def run(self, handler): # pragma: no cover
         from cherrypy import wsgiserver
-        server = wsgiserver.CherryPyWSGIServer((self.host, self.port), handler)
+        self.options['options']['bind_addr'] = (self.host, self.port)
+	self.options['options']['wsgi_app'] = handler
+        server = wsgiserver.CherryPyWSGIServer(**self.options['options'])
         try:
             server.start()
         finally:


### PR DESCRIPTION
Changing bottle run to accept options for cherrypy server like numofthreads and other options that are needed for cherrypy wsgiserver configuration.

For example in the example below i am specifying the number of threads to be created at startup by cherrypy as a options dictionary.

 run( APP, host = CONFIG.get( webserver, hostname ), port = CONFIG.get( webserver, port ),
         server = cherrypy, debug = CONFIG.get( webserver, debug ), options = {numthreads:30} )
