### PR TITLE
modified the cherrypy adapter to support ssl options

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2680,7 +2680,20 @@ class CherryPyServer(ServerAdapter):
         from cherrypy import wsgiserver
         self.options['bind_addr'] = (self.host, self.port)
         self.options['wsgi_app'] = handler
+        
+        certfile = self.options.get('certfile')
+        if certfile:
+            del self.options['certfile']
+        keyfile = self.options.get('keyfile')
+        if keyfile:
+            del self.options['keyfile']
+        
         server = wsgiserver.CherryPyWSGIServer(**self.options)
+        if certfile:
+            server.ssl_certificate = certfile
+        if keyfile:
+            server.ssl_private_key = keyfile
+        
         try:
             server.start()
         finally:


### PR DESCRIPTION
With this modification passing the keyword args "certfile" and "keyfile" to the bottle.run will enable ssl when cherrypy is the server option. 
