### PR TITLE
Edit JSONPlugin class so that list objects are automatically encoded as JSON

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ Thanks to all the people who found bugs, sent patches, spread the word, helped e
 * Johannes Krampf
 * Jonas Haag
 * Joshua Roesslein
+* Judson D Neer
 * Karl
 * Kevin Zuber
 * Kraken

--- a/bottle.py
+++ b/bottle.py
@@ -1726,13 +1726,13 @@ class JSONPlugin(object):
             except HTTPError:
                 rv = _e()
 
-            if isinstance(rv, dict):
+            if isinstance(rv, (dict, list)):
                 #Attempt to serialize, raises exception on failure
                 json_response = dumps(rv)
                 #Set content type only if serialization succesful
                 response.content_type = 'application/json'
                 return json_response
-            elif isinstance(rv, HTTPResponse) and isinstance(rv.body, dict):
+            elif isinstance(rv, HTTPResponse) and isinstance(rv.body, (dict, list)):
                 rv.body = dumps(rv.body)
                 rv.content_type = 'application/json'
             return rv


### PR DESCRIPTION
Hi Marcel, I've been using bottle for about a year now and love it, but wanted to suggest this change, as it's an issue I've run into several times:

Having a list as the root element of a JSON document is perfectly valid. The auto-decoding of JSON documents with lists at the root works just fine; this fix allows bottle to also automatically encode list objects to JSON.

(Also, this is my first time using GitHub's Pull Request feature, and I'm relatively new to Git also, so if I'm doing something wrong, please be gentle!)
