### PR TITLE
JSONPlugin also handles a list as return type

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1716,7 +1716,7 @@ class JSONPlugin(object):
             except HTTPError:
                 rv = _e()
 
-            if isinstance(rv, dict):
+            if isinstance(rv, dict) or isinstance(rv, list):
                 #Attempt to serialize, raises exception on failure
                 json_response = dumps(rv)
                 #Set content type only if serialization succesful


### PR DESCRIPTION
A list is also a valid basis for a JSON serialization. Therefore the JSONPlugin should also handle lists for return types.
