### PR TITLE
Fixed path being unshifted before returned generator exhausted.

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -650,7 +650,7 @@ class Bottle(object):
         path_depth = len(segments)
 
         def unshift():
-            yield
+            yield ""
             request.path_shift(-path_depth)
 
         def mountpoint_wrapper():
@@ -667,8 +667,8 @@ class Bottle(object):
                     for name, value in headerlist: rs.add_header(name, value)
                     return rs.body.append
                 body = app(request.environ, start_response)
-                if body and rs.body: rs.body = itertools.chain(rs.body, body, unshift)
-                else: rs.body = itertools.chain(body or rs.body, unshift)
+                if body and rs.body: rs.body = itertools.chain(rs.body, body, unshift())
+                else: rs.body = itertools.chain(body or rs.body, unshift())
                 return rs
             except:
                 request.path_shift(-path_depth)

--- a/bottle.py
+++ b/bottle.py
@@ -649,6 +649,10 @@ class Bottle(object):
         if not segments: raise ValueError('Empty path prefix.')
         path_depth = len(segments)
 
+        def unshift():
+            yield
+            request.path_shift(-path_depth)
+
         def mountpoint_wrapper():
             try:
                 request.path_shift(path_depth)
@@ -663,11 +667,12 @@ class Bottle(object):
                     for name, value in headerlist: rs.add_header(name, value)
                     return rs.body.append
                 body = app(request.environ, start_response)
-                if body and rs.body: body = itertools.chain(rs.body, body)
-                rs.body = body or rs.body
+                if body and rs.body: rs.body = itertools.chain(rs.body, body, unshift)
+                else: rs.body = itertools.chain(body or rs.body, unshift)
                 return rs
-            finally:
+            except:
                 request.path_shift(-path_depth)
+                raise
 
         options.setdefault('skip', True)
         options.setdefault('method', 'ANY')

--- a/test/test_mount.py
+++ b/test/test_mount.py
@@ -11,6 +11,14 @@ class TestAppMounting(ServerTestBase):
         def test(test='foo'):
             return test
 
+    def test_unshift(self):
+        self.app.mount('/test/', self.subapp)
+        @self.subapp.route('/unshift')
+        def test():
+            for i in xrange(2):
+                yield '%s\n' % bottle.request.environ["SCRIPT_NAME"]
+        self.assertBody('/test\n'*2, '/test/unshift')
+
     def test_mount(self):
         self.app.mount('/test/', self.subapp)
         self.assertStatus(404, '/')
@@ -61,7 +69,7 @@ class TestAppMounting(ServerTestBase):
         self.assertBody('WSGI /', '/test/')
         self.assertHeader('X-Test', 'WSGI', '/test/')
         self.assertBody('WSGI /test/bar', '/test/test/bar')
-            
+
     def test_mount_wsgi(self):
         @self.subapp.route('/cookie')
         def test_cookie():


### PR DESCRIPTION
I've experienced some request issues on long generator routes, mainly related to SCRIPT_NAME and PATH_INFO changing between yields.
After some debugging I've realized path_shift was being called before yielding, breaking all get_url calls on my partial templates from my mounted app.
This patch fixes that chaining the path_shift to response body, instead of calling right after return.
