### PR TITLE
Use gevent.sleep instead of time.sleep

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -168,15 +168,15 @@ Several "push" mechanisms like XHR multipart need the ability to write response 
 
     from gevent import monkey; monkey.patch_all()
 
-    import time
+    import gevent
     from bottle import route, run
     
     @route('/stream')
     def stream():
         yield 'START'
-        time.sleep(3)
+        gevent.sleep(3)
         yield 'MIDDLE'
-        time.sleep(5)
+        gevent.sleep(5)
         yield 'END'
     
     run(host='0.0.0.0', port=8080, server='gevent')


### PR DESCRIPTION
Use gevent.sleep instead of time.sleep to prevent blocking (just to educate the users not to use sleep):

http://stackoverflow.com/questions/12040880/how-to-avoid-blocking-code-in-python-with-gevent
