### PR TITLE
Multi-phase run for WSGIRefServer

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2045,7 +2045,6 @@ class ConfigDict(dict):
             >>> c.load_dict({'some': {'namespace': {'key': 'value'} } })
             {'some.namespace.key': 'value'}
         """
-
         for key, value in source.items():
             if isinstance(key, str):
                 nskey = (namespace + '.' + key).strip('.')
@@ -3000,6 +2999,7 @@ def create_server(app=None, server='wsgiref',
         server = server_names.get(server)
     if isinstance(server, basestring):
         server = load(server)
+
     if isinstance(server, type):
         server = server(host=host, port=port, **kargs)
     if not isinstance(server, ServerAdapter):


### PR DESCRIPTION
This is an initial stab at addressing issue #568. It's certainly not a complete solution, and it only works for the WSGIRefServer. What I'd like, if you have time, is some feedback on the approach. 

The basic idea is that I've separated the initialization of ServerAdapters from running them. This lets users optionally access the server before it starts serving, meaning that they can e.g. find the port that's been selected for them.

There are certainly other ways we could approach this, so if you'd prefer a different implementation I'd be more than happy to try it. This is a problem I'd like to see solved.
