### PR TITLE
Allow custom bind_addr for CherryPy

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2641,7 +2641,7 @@ class WSGIRefServer(ServerAdapter):
 class CherryPyServer(ServerAdapter):
     def run(self, handler): # pragma: no cover
         from cherrypy import wsgiserver
-        self.options['bind_addr'] = (self.host, self.port)
+        self.options.setdefault('bind_addr', (self.host, self.port))
         self.options['wsgi_app'] = handler
         
         certfile = self.options.get('certfile')


### PR DESCRIPTION
This is useful for listening on a unix socket, for running behind a reverse proxy.
