### PR TITLE
Fixed bottle.py:3343: ResourceWarning: unclosed file <_io.BufferedReader...

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3340,7 +3340,10 @@ class SimpleTemplate(BaseTemplate):
 
     @cached_property
     def code(self):
-        source = self.source or open(self.filename, 'rb').read()
+        source = self.source
+        if not source:
+            with open(self.filename, 'rb') as f:
+                source = f.read()
         try:
             source, encoding = touni(source), 'utf8'
         except UnicodeError:


### PR DESCRIPTION
The ressourceWarning appeard with Py 3.4 (or may be I did not notice it before....)
