### PR TITLE
report back actual port when using port 0

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2640,7 +2640,8 @@ class FlupFCGIServer(ServerAdapter):
 
 
 class WSGIRefServer(ServerAdapter):
-    def run(self, app): # pragma: no cover
+    def __init__(self, *args, **kwargs):
+        super(WSGIRefServer, self).__init__(*args, **kwargs)
         from wsgiref.simple_server import WSGIRequestHandler, WSGIServer
         from wsgiref.simple_server import make_server
         import socket
@@ -2660,8 +2661,11 @@ class WSGIRefServer(ServerAdapter):
                 class server_cls(server_cls):
                     address_family = socket.AF_INET6
 
-        srv = make_server(self.host, self.port, app, server_cls, handler_cls)
-        srv.serve_forever()
+        self.srv = make_server(self.host, self.port, app, server_cls, handler_cls)
+        self.port = self.srv.server_port # update port actual port (0 means random)
+    
+    def run(self, app): # pragma: no cover
+        self.srv.serve_forever()
 
 
 class CherryPyServer(ServerAdapter):


### PR DESCRIPTION
This patch reports the actual port being listened on to the command line.
I only did this for WSGIRefServer, maybe it should be done for others as well?

For example you'll now see 
    Listening on http://localhost:39881/
rather than
    Listening on http://localhost:0/
