### PR TITLE
Suppress ResourceWarning unclosed socket message

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2665,7 +2665,7 @@ class WSGIRefServer(ServerAdapter):
         self.port = self.srv.server_port # update port actual port (0 means random)
         try:
             self.srv.serve_forever()
-        except (KeyboardInterrupt) as e:
+        except KeyboardInterrupt:
             self.srv.server_close() # Prevent ResourceWarning: unclosed socket
             raise
 


### PR DESCRIPTION
When working with Python 3.3 and the `debug` parameter set to `True`, the default wsgiref server will emit a `ResourceWarning: unclosed <socket.socket object, fd=3, family=2, type=1, proto=0>` message when using ctrl+c to stop the server.

This change explicitly closes the server when ctrl+c is detected, preventing the warning from being displayed.
