### PR TITLE
fix coverage break gevent/eventlet testcase

### DIFF
--- a/test/servertest.py
+++ b/test/servertest.py
@@ -1,13 +1,8 @@
 if __name__ != '__main__':
     raise ImportError('This is not a module, but a script.')
 
-try:
-    import coverage
-    coverage.process_startup()
-except ImportError:
-    pass
-
 import sys, os, socket
+
 test_root = os.path.dirname(os.path.abspath(__file__))
 os.chdir(test_root)
 sys.path.insert(0, os.path.dirname(test_root))
@@ -23,6 +18,12 @@ try:
     elif server == 'eventlet':
         import eventlet
         eventlet.monkey_patch()
+
+    try:
+        import coverage
+        coverage.process_startup()
+    except ImportError:
+        pass
 
     from bottle import route, run
     route('/test', callback=lambda: 'OK')


### PR DESCRIPTION
The coverage.process_starup() will import threading which breaks gevent/eventlet monkey patch

Before the patch

```
python test/test_server.py
WARNING: Skipping 'meinheld' test (ImportError).
.WARNING: Skipping 'bjoern' test (ImportError).
.WARNING: Skipping 'cherrypy' test (ImportError).
.WARNING: Skipping 'diesel' test (ImportError).
..WARNING: Skipping 'fapws3' test (ImportError).
.E..WARNING: Skipping 'rocket' test (ImportError).
....
======================================================================
ERROR: test_simple (__main__.TestGeventServer)
Test a simple static page with this server adapter.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_server.py", line 79, in tearDown
    raise AssertionError(line.strip().decode('utf8'))
AssertionError: Exception KeyError: KeyError(139741601585264,) in <module 'threading' from '/usr/lib/python2.7/threading.pyc'> ignored

----------------------------------------------------------------------
Ran 13 tests in 6.463s

FAILED (errors=1)
```

After this PR

```
python test/test_server.py
WARNING: Skipping 'meinheld' test (ImportError).
.WARNING: Skipping 'bjoern' test (ImportError).
.WARNING: Skipping 'cherrypy' test (ImportError).
.WARNING: Skipping 'diesel' test (ImportError).
..WARNING: Skipping 'fapws3' test (ImportError).
....WARNING: Skipping 'rocket' test (ImportError).
....
----------------------------------------------------------------------
Ran 13 tests in 6.463s

OK
```
