### PR TITLE
Make `root='/'` work cross-platform

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2352,7 +2352,7 @@ def static_file(filename, root, mimetype='auto', download=False, charset='UTF-8'
             mime-type. (default: UTF-8)
     """
 
-    root = os.path.abspath(root) + os.sep
+    root = os.path.join(os.path.abspath(root), '')
     filename = os.path.abspath(os.path.join(root, filename.strip('/\\')))
     headers = dict()
 


### PR DESCRIPTION
If `root` already ends in `os.sep`, don't add another one

This used to fail on windows, but somehow worked on unix