### PR TITLE
Get mime type from download, if download is a file name

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2365,7 +2365,10 @@ def static_file(filename, root, mimetype='auto', download=False, charset='UTF-8'
         return HTTPError(403, "You do not have permission to access this file.")
 
     if mimetype == 'auto':
-        mimetype, encoding = mimetypes.guess_type(filename)
+        if download and download != True:
+            mimetype, encoding = mimetypes.guess_type(download)
+        else:
+            mimetype, encoding = mimetypes.guess_type(filename)
         if encoding: headers['Content-Encoding'] = encoding
 
     if mimetype:

--- a/test/test_sendfile.py
+++ b/test/test_sendfile.py
@@ -78,6 +78,8 @@ class TestSendFile(unittest.TestCase):
 
     def test_download(self):
         """ SendFile: Download as attachment """
+        f = static_file(os.path.basename(__file__), root='./', download="foo.mp3")
+        self.assertEqual('audio/mpeg', f.headers['Content-Type'])
         basename = os.path.basename(__file__)
         f = static_file(basename, root='./', download=True)
         self.assertEqual('attachment; filename="%s"' % basename, f.headers['Content-Disposition'])


### PR DESCRIPTION
Get mime type from the download parameter instead of from the file, if
download is a file name. (added test for this too)

Use case: This helps when files are stored on disk as e.g. "4", "36" or "6d2fb3bfe024805b692280b65f9636ad" (as blobs basically for a database). The file name with suffix would then typically be taken from metadata in a database and added to the download with the download parameter.
