### PR TITLE
Update CherryPy SSL to use latest API and work on Py3

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2698,10 +2698,9 @@ class CherryPyServer(ServerAdapter):
             del self.options['keyfile']
         
         server = wsgiserver.CherryPyWSGIServer(**self.options)
-        if certfile:
-            server.ssl_certificate = certfile
-        if keyfile:
-            server.ssl_private_key = keyfile
+        if certfile and keyfile:
+            ssl_adapter = wsgiserver.get_ssl_adapter_class()
+            server.ssl_adapter = ssl_adapter(certificate=certfile, private_key=keyfile)
         
         try:
             server.start()


### PR DESCRIPTION
On Py2, the `ssl_certificate` and `ssl_private_key` attributes are deprecated, and on Py3 they don't exist at all!

This PR just updates the code to use BottlePy's recommended `ssl_adapter` method, fixing it for Python3.

That said, I haven't actually been able to get this to work with Py2. Neither this nor the previous version work on Python2 for me, and they both result in a non-ssl server, but I suspect that's a CherryPy issue with my particular environment. Mind trying this out with a Py2 server on your own box before pulling it? I've got some test server code [here](https://gist.github.com/DanielOaks/d99607ffda205d6664e2)
