### PR TITLE
fixes issue #671

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -852,27 +852,33 @@ class Bottle(object):
             environ['bottle.app'] = self
             request.bind(environ)
             response.bind()
-            try:
-                self.trigger_hook('before_request')
-                route, args = self.router.match(environ)
-                environ['route.handle'] = route
-                environ['bottle.route'] = route
-                environ['route.url_args'] = args
-                return route.call(**args)
-            finally:
-                self.trigger_hook('after_request')
+            out = None
+            self.trigger_hook('before_request')
+            route, args = self.router.match(environ)
+            environ['route.handle'] = route
+            environ['bottle.route'] = route
+            environ['route.url_args'] = args
+            out = route.call(**args)
+            return out
         except HTTPResponse:
-            return _e()
+            out = _e()
+            return out
         except RouteReset:
             route.reset()
-            return self._handle(environ)
+            out = self._handle(environ)
+            return out
         except (KeyboardInterrupt, SystemExit, MemoryError):
             raise
         except Exception:
             if not self.catchall: raise
             stacktrace = format_exc()
             environ['wsgi.errors'].write(stacktrace)
-            return HTTPError(500, "Internal Server Error", _e(), stacktrace)
+            out = HTTPError(500, "Internal Server Error", _e(), stacktrace)
+            return out
+        finally:
+            if out:
+                out.apply(response)
+            self.trigger_hook('after_request')
 
     def _cast(self, out, peek=None):
         """ Try to convert the parameter into something WSGI compatible and set


### PR DESCRIPTION
I'm quite new to Bottle but I've tried to look into this. At [line 861](https://github.com/bottlepy/bottle/blob/master/bottle.py#L861) we get the output of our selected route call. The returned object of `route.call` doesn't update the global `response` object and so when we go into the `finally` block we're dealing with an out of date response.

Furthermore, in case of a 404, we never get to `route.call` and immediately go into the `except HTTPResponse` which also never updates the global response object and so the finally block will get the wrong result.

This updating is done by the `out.apply(response)` method which is called in the `_cast()` method. Unfortunately this is too late because the `after_request` has already been processed.

I don't really know if this is a good solution but I think I've fixed it by creating an `out` variable which gets the updated response object, use the `apply` method in an outer finally block and only then triggering the hook.

Not sure if this is hackish or ugly, but I'm not used to contributing so any feedback would be great.