### PR TITLE
Add SSL/TLS support to TwistedServer

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2787,17 +2787,14 @@ class TwistedServer(ServerAdapter):
         factory = server.Site(wsgi.WSGIResource(reactor, thread_pool, handler))
 
         certfile = self.options.get('certfile')
-        if certfile:
-            del self.options['certfile']
         keyfile = self.options.get('keyfile')
-        if keyfile:
-            del self.options['keyfile']
 
         if certfile and keyfile:
             reactor.listenSSL(self.port, factory,
                 ssl.DefaultOpenSSLContextFactory(keyfile, certfile))
         else:
             reactor.listenTCP(self.port, factory, interface=self.host)
+
         if not reactor.running:
             reactor.run()
 

--- a/bottle.py
+++ b/bottle.py
@@ -2780,33 +2780,26 @@ class TwistedServer(ServerAdapter):
     def run(self, handler):
         from twisted.web import server, wsgi
         from twisted.python.threadpool import ThreadPool
-        # CHANGE: ilovetux
         from twisted.internet import reactor, ssl
         thread_pool = ThreadPool()
         thread_pool.start()
         reactor.addSystemEventTrigger('after', 'shutdown', thread_pool.stop)
         factory = server.Site(wsgi.WSGIResource(reactor, thread_pool, handler))
-        # CHANGE: ilovetux
-        # Grab certfile and keyfile (try to stick to convention by copying
-        # code from CherryPyServer)
+
         certfile = self.options.get('certfile')
         if certfile:
             del self.options['certfile']
         keyfile = self.options.get('keyfile')
         if keyfile:
             del self.options['keyfile']
-        # CHANGE: ilovetux
-        # if cerfile and keyfile were provided in options, then have the
-        # reactor listen using SSL/TLS, otherwise fallback to listenTCP
-        # This is as per recomendations from:
-        #
-        # http://twistedmatrix.com/documents/12.3.0/core/howto/ssl.html
+
         if certfile and keyfile:
             reactor.listenSSL(self.port, factory,
                 ssl.DefaultOpenSSLContextFactory(keyfile, certfile))
         else:
             reactor.listenTCP(self.port, factory, interface=self.host)
-        reactor.run()
+        if not reactor.running:
+            reactor.run()
 
 
 class DieselServer(ServerAdapter):

--- a/bottle.py
+++ b/bottle.py
@@ -2701,7 +2701,7 @@ class CherryPyServer(ServerAdapter):
             server.ssl_certificate = certfile
         if keyfile:
             server.ssl_private_key = keyfile
-        
+
         try:
             server.start()
         finally:
@@ -2780,14 +2780,33 @@ class TwistedServer(ServerAdapter):
     def run(self, handler):
         from twisted.web import server, wsgi
         from twisted.python.threadpool import ThreadPool
-        from twisted.internet import reactor
+        # CHANGE: ilovetux
+        from twisted.internet import reactor, ssl
         thread_pool = ThreadPool()
         thread_pool.start()
         reactor.addSystemEventTrigger('after', 'shutdown', thread_pool.stop)
         factory = server.Site(wsgi.WSGIResource(reactor, thread_pool, handler))
-        reactor.listenTCP(self.port, factory, interface=self.host)
-        if not reactor.running:
-            reactor.run()
+        # CHANGE: ilovetux
+        # Grab certfile and keyfile (try to stick to convention by copying
+        # code from CherryPyServer)
+        certfile = self.options.get('certfile')
+        if certfile:
+            del self.options['certfile']
+        keyfile = self.options.get('keyfile')
+        if keyfile:
+            del self.options['keyfile']
+        # CHANGE: ilovetux
+        # if cerfile and keyfile were provided in options, then have the
+        # reactor listen using SSL/TLS, otherwise fallback to listenTCP
+        # This is as per recomendations from:
+        #
+        # http://twistedmatrix.com/documents/12.3.0/core/howto/ssl.html
+        if certfile and keyfile:
+            reactor.listenSSL(self.port, factory,
+                ssl.DefaultOpenSSLContextFactory(keyfile, certfile))
+        else:
+            reactor.listenTCP(self.port, factory, interface=self.host)
+        reactor.run()
 
 
 class DieselServer(ServerAdapter):


### PR DESCRIPTION
First I would like to apologize for any problems related to this pull request, as it is my first pull request on someone else's repository.

The idea here is to add SSL support to the TwistedServer ServerAdapter.

You can see in the comments everything I will say below, but for the sake of completeness:

I try to stick to your conventions as close as possible (I cannot fix the spaces in CherryPyServer that my text editor [NinjaIDE] added). I used a method similar to the one in CherryPyServer to test for certfile and keyfile, and depending on whether they were passed I use the method described [here](http://twistedmatrix.com/documents/12.3.0/core/howto/ssl.html) to have the reactor listenSSL or to listenTCP as the original implementation did.

Please let me know if this pull request adheres to your standards and if not how I can improve for next time. Thank you for your time and consideration.
