### PR TITLE
fixes #671 and add pass exception to `after_request` hook callback when it it occured.

### DIFF
--- a/test/test_wsgi.py
+++ b/test/test_wsgi.py
@@ -250,7 +250,7 @@ class TestRouteDecorator(ServerTestBase):
         def hook():
             bottle.request.environ['hooktest'] = 'before'
         @bottle.hook('after_request')
-        def hook():
+        def hook(*args, **kwargs):
             bottle.response.headers['X-Hook'] = 'after'
         self.assertBody('before', '/test')
         self.assertHeader('X-Hook', 'after', '/test')


### PR DESCRIPTION
First, `before_request` and `after_request` is very useful hooks for resource management, but `after_request` must know has any exception is raised while request be processing, for decide how to release resource, commit or rollback database transaction for example.
Then, I read @vascop 's PR https://github.com/bottlepy/bottle/pull/702/files and got some inspire. But his code still have some bugs, such as when RouteReset is raise, `after_request` hook callback will be called twice.
So, I extracted some code from _handle() to _inner_handle(). Collected exception and pass it to `after_request` hook callback, if not error, the argument `exc` will be None.