### PR TITLE
Added another recipe for removing trailing slashes

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -139,7 +139,7 @@ For Bottle, ``/example`` and ``/example/`` are two different routes [1]_. To tre
     @route('/test/')
     def test(): return 'Slash? no?'
 
-or add a WSGI middleware that strips trailing slashes from all URLs::
+add a WSGI middleware that strips trailing slashes from all URLs::
 
     class StripPathMiddleware(object):
       def __init__(self, app):
@@ -151,6 +151,12 @@ or add a WSGI middleware that strips trailing slashes from all URLs::
     app = bottle.app()
     myapp = StripPathMiddleware(app)
     bottle.run(app=myapp)
+
+or add a ``before_request`` hook to strip the trailing slashes::
+
+    @hook('before_request')
+    def strip_path():
+        request.environ['PATH_INFO'] = request.environ['PATH_INFO'].rstrip('/')
 
 .. rubric:: Footnotes
 


### PR DESCRIPTION
This one is using a `before_request` hook to strip the trailing slash from `request.environ['PATH_INFO']`. I prefer it to the WSGI middleware method because it leaves the API of the app intact. For example, in the `StripPathMiddleware` snippet, you can't later add a route to `myapp` because you'll get the following error: `AttributeError: 'StripPathMiddleware' object has no attribute 'route'`.