### PR TITLE
Fix wsgi.input lookup and demonstrate unit tests that need a request body

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1167,7 +1167,7 @@ class BaseRequest(object):
     @DictProperty('environ', 'bottle.request.body', read_only=True)
     def _body(self):
         body_iter = self._iter_chunked if self.chunked else self._iter_body
-        read_func = self.environ['wsgi.input'].read
+        read_func = self.environ.get('wsgi.input', BytesIO()).read
         body, body_size, is_temp_file = BytesIO(), 0, False
         for part in body_iter(read_func, self.MEMFILE_MAX):
             body.write(part)

--- a/test/test_oorouting.py
+++ b/test/test_oorouting.py
@@ -1,0 +1,34 @@
+"""
+Tests & demonstrates various OO approaches to routes
+"""
+import unittest
+from io import BytesIO
+
+__author__ = 'atc'
+
+from bottle import Bottle, request, tob, BaseRequest
+
+
+class TestRouter(object):
+    """
+    A test class for wrapping routes to test certain OO scenarios
+    """
+
+    app = Bottle()
+
+    @app.post("/route1/<msg>")
+    def route_1(self, msg):
+        body = request.body.readline()
+        return {'msg': msg, 'len': len(body)}
+
+
+class TestRoutes(unittest.TestCase):
+    def test_route1(self):
+        body = "abc"
+        request.environ['CONTENT_LENGTH'] = str(len(tob(body)))
+        request.environ['wsgi.input'] = BytesIO()
+        request.environ['wsgi.input'].write(tob(body))
+        request.environ['wsgi.input'].seek(0)
+
+        result = TestRouter().route_1("bob")
+        self.assertEqual(result, dict(msg="bob", len=3))

--- a/test/test_oorouting.py
+++ b/test/test_oorouting.py
@@ -2,7 +2,12 @@
 Tests & demonstrates various OO approaches to routes
 """
 import unittest
-from io import BytesIO
+import sys
+
+if sys.version_info >= (3, 0, 0):
+    from io import BytesIO
+else:
+    from StringIO import StringIO as BytesIO
 
 __author__ = 'atc'
 


### PR DESCRIPTION
Regarding issue #727 . I've fixed the runtime error by first creating a failing test which also demonstrates (for users of bottle.py) how to unit test a route function that uses a body. I couldn't personally see this anywhere on the web or in bottle.py's documentation.

Hopefully this is useful and to conventions/tastes of the project. I will happily provide a short documentation paragraph for the docs on bottlepy.org but have yet to work out how to do so.