### PR TITLE
.get_undecorated_callback() bugfix

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -42,6 +42,7 @@ if __name__ == '__main__':
 import base64, cgi, email.utils, functools, hmac, imp, itertools, mimetypes,\
         os, re, subprocess, sys, tempfile, threading, time, warnings
 
+from types import FunctionType
 from datetime import date as datedate, datetime, timedelta
 from tempfile import TemporaryFile
 from traceback import format_exc, print_exc
@@ -543,7 +544,16 @@ class Route(object):
         func = getattr(func, '__func__' if py3k else 'im_func', func)
         closure_attr = '__closure__' if py3k else 'func_closure'
         while hasattr(func, closure_attr) and getattr(func, closure_attr):
-            func = getattr(func, closure_attr)[0].cell_contents
+            attributes = getattr(func, closure_attr)
+            func = attributes[0].cell_contents
+
+            # in case of decorators with multiple arguments
+            if func is not None and not isinstance(func, FunctionType):
+                # pick first FunctionType instance from multiple arguments
+                func = filter(
+                    lambda x: isinstance(x, FunctionType),
+                    map(lambda x: x.cell_contents, attributes)
+                )[0]
         return func
 
     def get_callback_args(self):

--- a/test/test_route.py
+++ b/test/test_route.py
@@ -51,7 +51,6 @@ class TestRoute(unittest.TestCase):
             return pretty_dump_wrapper
 
         # multiple decorators
-        @bottle.get("somepath")
         @d2(filename='foo', table='bar')
         @pretty_dump
         def x(a, b):

--- a/test/test_route.py
+++ b/test/test_route.py
@@ -28,3 +28,39 @@ class TestRoute(unittest.TestCase):
         self.assertEqual(route.get_undecorated_callback(), x)
         self.assertEqual(set(route.get_callback_args()), set(['a', 'b']))
 
+    def test_callback_inspection_multiple_args(self):
+        def x(a, b):
+            pass
+
+        # decorator with multiple arguments
+        def d2(fn=None, arg1="something", arg2="something else"):
+            def d(f):
+                def w(*args, **kwargs):
+                    return f()
+                return w
+
+            # support for calling this decorator without arguments
+            if fn:
+                return d(fn)
+
+            return d
+
+        # both decorator parameters
+        route = bottle.Route(None, None, None, d2(arg1='foo', arg2='bar')(x))
+        self.assertEqual(route.get_undecorated_callback(), x)
+        self.assertEqual(set(route.get_callback_args()), set(['a', 'b']))
+
+        # first decorator parameter
+        route = bottle.Route(None, None, None, d2(arg1='foo')(x))
+        self.assertEqual(route.get_undecorated_callback(), x)
+        self.assertEqual(set(route.get_callback_args()), set(['a', 'b']))
+
+        # second decorator parameter
+        route = bottle.Route(None, None, None, d2(arg2='bar')(x))
+        self.assertEqual(route.get_undecorated_callback(), x)
+        self.assertEqual(set(route.get_callback_args()), set(['a', 'b']))
+
+        # without decorator parameters
+        route = bottle.Route(None, None, None, d2()(x))
+        self.assertEqual(route.get_undecorated_callback(), x)
+        self.assertEqual(set(route.get_callback_args()), set(['a', 'b']))


### PR DESCRIPTION
I've found obscure error triggered in case of decorators with multiple parameters.

Now, the ``.get_undecorated_callback()`` method just picks first attribute, which doesn't have to be function, but also one of the parameters of decorator with multiple parameters.

For example, this decorator will trigger the bug:

```python
def database_decorator(fn=None, filename="default.sqlite", table="default"):
    """
    Open connection to the database and offer it to the wrapped function.

    So far, there is no database, only primitive JSON load/store system.
    """
    def database_decorator_wrapper(fn):
        @wraps(fn)
        def database_wrapper(*args, **kwargs):
            path = filename
            if not os.path.isabs(path):
                path = os.path.join(settings.DATABASE_PATH, path)

            # load database
            db = SqliteDict(
                path,
                # autocommit=True
            )

            # load table
            table_ref = db.get(table, {})

            # put table to function parameters
            kwargs["db"] = table_ref

            out = fn(*args, **kwargs)

            # save database
            db[table] = table_ref
            db.commit()

            return out

        return database_wrapper

    if fn:  # python decorator with optional parameters bukkake
        return database_decorator_wrapper(fn)

    return database_decorator_wrapper
```

My patch just looks for cases when the ``func`` is not ``FunctionType`` instance (which it should be) and then goes thru all the parameters and pick first ``FunctionType`` instance.