### PR TITLE
Newer versions of apache use a slightly different configuration

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -123,6 +123,21 @@ The Apache configuration may look like this::
         </Directory>
     </VirtualHost>
 
+With newer versions of Apache (2.4) use a configuration similar to this::
+
+    <VirtualHost *>
+        ServerName example.com
+        
+        WSGIDaemonProcess yourapp user=www-data group=www-data processes=1 threads=5
+        WSGIScriptAlias / /var/www/yourapp/app.wsgi
+        
+        <Directory /var/www/yourapp>
+            WSGIProcessGroup yourapp
+            WSGIApplicationGroup %{GLOBAL}
+            Require all granted
+        </Directory>
+    </VirtualHost>
+
 
 
 Google AppEngine


### PR DESCRIPTION
The current example of apache virtual server does not work with Apache 2.4. I added an example that works with that version.