### PR TITLE
make load_app() work on modules in cwd when bottle is called via a script

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3148,7 +3148,16 @@ def load(target, **namespace):
         local variables. Example: ``import_string('re:compile(x)', x='[a-z]')``
     """
     module, target = target.split(":", 1) if ':' in target else (target, None)
-    if module not in sys.modules: __import__(module)
+    if module not in sys.modules:
+        try:
+            __import__(module)
+        except ImportError:
+            # cwd is not always in sys.path, e.g when using scripts
+            if os.getcwd() in sys.path:
+                raise
+            sys.path.append(os.getcwd())
+            __import__(module)
+            sys.path.remove(os.getcwd())
     if not target: return sys.modules[module]
     if target.isalnum(): return getattr(sys.modules[module], target)
     package_name = module.split('.')[0]


### PR DESCRIPTION
For example, if you call a python script that launches
bottle, it is the path of the script that gets added
to `sys.path`, *not* the current directory. But it is
with respect to the current directory that I would like
to specify the value for `app`:

https://github.com/bottlepy/bottle/blob/0.12.8/bottle.py#L3044-L3045

This makes it so that the application/target can be found,
if it is in the current directory, even if you are
calling another script somewhere else that ultimately
hands over to bottle, and thus the `load_app()` function

The error avoided is:

```python
ImportError: No module named my_app
```

When I execute a script that passes the value `"my_app"`
to `bottle.run(app=value)`