### PR TITLE
Fix minor error in getargspec

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -92,7 +92,7 @@ try:
                 args.append(name)
                 if param.default is not param.empty:
                     defaults.append(param.default)
-        return (args, varargs, keywords, tuple(defaults) or defaults)
+        return (args, varargs, keywords, tuple(defaults) or None)
 except ImportError:
     from inspect import getargspec
     


### PR DESCRIPTION
A followup to #794.

From the documentation:

> defaults is a tuple of default argument values or None if there are no default arguments

so `return (args, varargs, keywords, tuple(defaults) or defaults)` should be `return (args, varargs, keywords, tuple(defaults) or None)`.

Sorry for this.
