### PR TITLE
Fix to enable async based wsgi server to support yield and yield from in endpoints

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -987,7 +987,7 @@ class Bottle(object):
             environ['PATH_INFO'] = path.encode('latin1').decode('utf8', 'ignore')
 
         def _inner_handle():
-            # Maybe pass variables as locals for better performance? 
+            # Maybe pass variables as locals for better performance?
             try:
                 route, args = self.router.match(environ)
                 environ['route.handle'] = route
@@ -1066,8 +1066,8 @@ class Bottle(object):
         try:
             iout = iter(out)
             first = next(iout)
-            while not first:
-                first = next(iout)
+            #while not first:  # this interferes with async driven endpoints
+                #first = next(iout)
         except StopIteration:
             return self._cast('')
         except HTTPResponse:


### PR DESCRIPTION
The code in _cast that checks for the content type of iterable interferes with async based wsgi servers where the async endpoints are generators that yield or yield from while waiting for io.

``` python

# Handle Iterables. We peek into them to detect their inner type.
        try:
            iout = iter(out)
            first = next(iout)
            while not first:  # this interferes with async driven endpoints
                first = next(out)
```
Change to
``` python

# Handle Iterables. We peek into them to detect their inner type.
        try:
            iout = iter(out)
            first = next(iout)
           
```

The problem is that this code greedily consumes the iterable until there is non empty content. But it does not need to. An empty unicode string or an empty bytes will still suffice to determine the type.  There may be a use case for an iterable to return an empty string of a different type than what the non empty will be but that seems counter intuitive. The other cases where the itterable returns and HTTPResponse object I don't know about.




Type check still works in the event of an empty string but allows an endpoint to yield an empty string while its async waiting for async io to complete.

For example

``` python
@app.get('/register/<uid>')
def registerGet(uid):
        """
        Example of async endpoint
        """
       # must set content-type before first yield
        bottle.response.set_header('content-type', 'application/json')

        response = yield from myAsyncCoroutine()  # yields "" while not yet completed
        result = json.dumps(response)
        (yield result)

def myAsyncCoroutine():
     while True:
        # Async io here
        if done:
             break
        yield ''  # this is eventually yielded by wsgi app while waiting
     return response
```

I believe this is still compatible with PEP 3333 (see below)as start response has to keep iterating until it gets a
non empty return. This allows the WSGI server to drive the async endpoint coroutine by repeatedly calling the iterater. This allows very simple execution of async wsgi apps. The bottle.run is no longer necessary.

For example the following service routine is repeatedly called by an async scheduler running the the
wsgi http server:

``` python

def service(self):
        """
        Service application
        """
        if not self.closed and not self.ended:
            if self.iterator is None:  # initiate application
                self.iterator = iter(self.app(self.environ, self.start))

            try:
                msg = next(self.iterator)
            except StopIteration:
                self.write(b"")  # if chunked write will send empty chunk to terminate
                self.ended = True
            else:
                if msg:
                    self.write(msg)
                    if self.length is not None and self.size >= self.length:
                        self.ended = True
```
where self.app in this case is a bottle app

With the changes I am able to get my async http server to support yield and yield from in the bottle endpoints where they yield empty strings while waiting for async io operations to complete before returning the response from the endpoint.

From PEP 3333
"However, the start_response callable must not actually transmit the response headers. Instead, it must store them for the server or gateway to transmit only after the first iteration of the application return value that yields a non-empty bytestring, or upon the application's first invocation of the write() callable. In other words, response headers must not be sent until there is actual body data available, or until the application's returned iterable is exhausted. (The only possible exception to this rule is if the response headers explicitly include a Content-Length of zero.)"

