### PR TITLE
Fixed Jinja2 File Templates unusable since e456b4f

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3631,7 +3631,10 @@ class Jinja2Template(BaseTemplate):
         return self.tpl.render(**_defaults)
 
     def loader(self, name):
-        fname = self.search(name, self.lookup)
+        if os.path.isabs(name):
+            fname = name if os.path.isfile(name) else None
+        else:
+            fname = self.search(name, self.lookup)
         if not fname: return
         with open(fname, "rb") as f:
             return f.read().decode(self.encoding)

--- a/test/test_jinja2.py
+++ b/test/test_jinja2.py
@@ -13,7 +13,7 @@ class TestJinja2Template(unittest.TestCase):
 
     def test_file(self):
         """ Templates: Jinja2 file"""
-        t = Jinja2Template(name='./views/jinja2_simple.tpl').render(var='var')
+        t = Jinja2Template(name='./views/jinja2_simple.tpl', lookup=['.']).render(var='var')
         self.assertEqual('start var end', ''.join(t))
 
     def test_name(self):


### PR DESCRIPTION
This patch re-establish the possibility to use jinja2 templates.

Example, without it:
```
$ cat views/hello.tpl 
Hi!
```

```
$ cat hello.py 
from bottle import jinja2_template

print(jinja2_template('hello'))
```

```
$ python hello.py
[...]
    "Refer to templates with names or paths relative to the lookup path.")
DeprecationWarning: Warning: Use of deprecated feature or API. (Deprecated in Bottle-0.12)
Cause: Use of absolute path for template name.
Fix: Refer to templates with names or paths relative to the lookup path.
```

The bug is also visible with "test_jinja2"