### PR TITLE
Fixing initial copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015, Marcel Hellkamp.
+Copyright (c) 2011-2016, Marcel Hellkamp.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
According to http://www.copyright.gov/circs/circ01.pdf , document should list its first year of publication in its copyright

As the license was applied back in 2011 ( As per the commit - 4047cda0ab5aaa ), therefore creating a range from 2011-2016