### PR TITLE
Mixin args into kwargs earlier in template()

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3950,6 +3950,8 @@ def template(*args, **kwargs):
     or directly (as keyword arguments).
     """
     tpl = args[0] if args else None
+    for dictarg in args[1:]:
+        kwargs.update(dictarg)
     adapter = kwargs.pop('template_adapter', SimpleTemplate)
     lookup = kwargs.pop('template_lookup', TEMPLATE_PATH)
     tplid = (id(lookup), tpl)
@@ -3964,8 +3966,6 @@ def template(*args, **kwargs):
             TEMPLATES[tplid] = adapter(name=tpl, lookup=lookup, **settings)
     if not TEMPLATES[tplid]:
         abort(500, 'Template (%s) not found' % tpl)
-    for dictarg in args[1:]:
-        kwargs.update(dictarg)
     return TEMPLATES[tplid].render(kwargs)
 
 


### PR DESCRIPTION
In short: `@view('some_template', template_lookup='./app/my_vews')` won't work

I want to add a lookup-path for templates in my app, so I hook `view` and add `temlate_lookup` to kwargs but it doesn't work.

``` python
from . import bottle
from .bottle import route, request, response

from . import config

view = functools.partial(bottle.view, template_lookup=[config.PATH + '/pages'])
```

This patch fix the problem by mixin args earlier.