### PR TITLE
Example behaves as a synchronous server

### DIFF
--- a/docs/async.rst
+++ b/docs/async.rst
@@ -86,6 +86,9 @@ Lets forget about the low-level details for a while and speak about WebSockets. 
 Thankfully the `gevent-websocket <http://pypi.python.org/pypi/gevent-websocket/>`_ package does all the hard work for us. Here is a simple WebSocket endpoint that receives messages and just sends them back to the client::
 
     from bottle import request, Bottle, abort
+    from gevent import monkey
+    
+    monkey.patch_all()  # without this line the server responds to requests synchronously
     app = Bottle()
 
     @app.route('/websocket')


### PR DESCRIPTION
monkey.patch_all () without this line the server responds to requests synchronously

``` python
from bottle import request, Bottle, abort
from gevent import monkey
import time

monkey.patch_all()
app = Bottle()


@app.get("/example")
def example():
    print("init")
    time.sleep(2)
    print("end")


@app.route('/websocket')
def handle_websocket():
    wsock = request.environ.get('wsgi.websocket')
    if not wsock:
        abort(400, 'Expected WebSocket request.')

    while True:
        try:
            message = wsock.receive()
            wsock.send("Your message was: %r" % message)
        except WebSocketError:
            break

if __name__ == "__main__":
    from gevent.pywsgi import WSGIServer
    from geventwebsocket import WebSocketError
    from geventwebsocket.handler import WebSocketHandler
    server = WSGIServer(("0.0.0.0", 9876), app,
                        handler_class=WebSocketHandler)
    server.serve_forever()

```

```
init
init
init
init
end
end
end
end
```

``` python
from bottle import request, Bottle, abort
import time

app = Bottle()


@app.get("/example")
def example():
    print("init")
    time.sleep(2)
    print("end")


@app.route('/websocket')
def handle_websocket():
    wsock = request.environ.get('wsgi.websocket')
    if not wsock:
        abort(400, 'Expected WebSocket request.')

    while True:
        try:
            message = wsock.receive()
            wsock.send("Your message was: %r" % message)
        except WebSocketError:
            break

if __name__ == "__main__":
    from gevent.pywsgi import WSGIServer
    from geventwebsocket import WebSocketError
    from geventwebsocket.handler import WebSocketHandler
    server = WSGIServer(("0.0.0.0", 9876), app,
                        handler_class=WebSocketHandler)
    server.serve_forever()

```

```
init
end
init
end
init
end
init
end
```