### PR TITLE
remove deprecated logic from GeventServer

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3204,21 +3204,18 @@ class DieselServer(ServerAdapter):
 class GeventServer(ServerAdapter):
     """ Untested. Options:
 
-        * `fast` (default: False) uses libevent's http server, but has some
-          issues: No streaming, no pipelining, no SSL.
         * See gevent.wsgi.WSGIServer() documentation for more options.
     """
 
     def run(self, handler):
-        from gevent import wsgi, pywsgi, local
+        from gevent import pywsgi, local
         if not isinstance(threading.local(), local.local):
             msg = "Bottle requires gevent.monkey.patch_all() (before import)"
             raise RuntimeError(msg)
-        if not self.options.pop('fast', None): wsgi = pywsgi
         if self.quiet:
             self.options['log'] = None
         address = (self.host, self.port)
-        server = wsgi.WSGIServer(address, handler, **self.options)
+        server = pywsgi.WSGIServer(address, handler, **self.options)
         if 'BOTTLE_CHILD' in os.environ:
             import signal
             signal.signal(signal.SIGINT, lambda s, f: server.stop())


### PR DESCRIPTION
gevent.wsgi just backwards compatibility alias for gevent.pywsgi, `fast` option was useless.
see:
http://www.gevent.org/gevent.wsgi.html
https://github.com/gevent/gevent/commits/v1.1.1/gevent/wsgi.py