### PR TITLE
Clean python 2.6 - No body should be using it anymore it's EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015, Marcel Hellkamp.
+Copyright (c) 2016, Marcel Hellkamp.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PATH := build/python/bin:$(PATH)
 VERSION = $(shell python setup.py --version)
 ALLFILES = $(shell echo bottle.py test/*.py test/views/*.tpl)
 
-.PHONY: release coverage install docs test test_all test_26 test_27 test_32 test_33 test_34 test_35 2to3 clean
+.PHONY: release coverage install docs test test_all test_27 test_32 test_33 test_34 test_35 2to3 clean
 
 release: test_all
 	python setup.py --version | egrep -q -v '[a-zA-Z]' # Fail on dev/rc versions
@@ -32,10 +32,7 @@ docs:
 test:
 	python test/testall.py
 
-test_all: test_26 test_27 test_32 test_33 test_34 test_35
-
-test_26:
-	python2.6 test/testall.py
+test_all: test_27 test_32 test_33 test_34 test_35
 
 test_27:
 	python2.7 test/testall.py

--- a/bottle.py
+++ b/bottle.py
@@ -170,21 +170,13 @@ else:  # 2.x
     from StringIO import StringIO as BytesIO
     from ConfigParser import SafeConfigParser as ConfigParser, \
                              Error as ConfigParserError
-    if py25:
-        from UserDict import DictMixin
-
-        def next(it):
-            return it.next()
-
-        bytes = str
-    else:  # 2.6, 2.7
-        from collections import MutableMapping as DictMixin
+    from collections import MutableMapping as DictMixin
     unicode = unicode
     json_loads = json_lds
     eval(compile('def _raise(*a): raise a[0], a[1], a[2]', '<py3fix>', 'exec'))
 
-if py25 or py31:
-    msg = "Python 2.5 and 3.1 support will be dropped in future versions of Bottle."
+if py31:
+    msg = "Python 3.1 support will be dropped in future versions of Bottle."
     warnings.warn(msg, DeprecationWarning)
 
 # Some helpers for string/byte handling

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ try:
 except ImportError:
     from distutils.core import setup
 
-if sys.version_info < (2, 6):
-    raise NotImplementedError("Sorry, you need at least Python 2.6 or Python 3.2+ to use bottle.")
+if sys.version_info < (2, 7):
+    raise NotImplementedError("Sorry, you need at least Python 2.7 or Python 3.2+ to use bottle.")
 
 import bottle
 
@@ -32,8 +32,6 @@ setup(name='bottle',
                    'Topic :: Internet :: WWW/HTTP :: WSGI :: Middleware',
                    'Topic :: Internet :: WWW/HTTP :: WSGI :: Server',
                    'Topic :: Software Development :: Libraries :: Application Frameworks',
-                   'Programming Language :: Python :: 2.5',
-                   'Programming Language :: Python :: 2.6',
                    'Programming Language :: Python :: 2.7',
                    'Programming Language :: Python :: 3',
                    'Programming Language :: Python :: 3.2',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py27-most
+envlist = py27,py32,py33,py27-most
 
 [testenv]
 deps=Mako


### PR DESCRIPTION
We are almost 2 years after end of life ...

PEP-361:
    Oct 29 2013: Python 2.6.9 final released (security-only)

