### PR TITLE
Clean python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015, Marcel Hellkamp.
+Copyright (c) 2016, Marcel Hellkamp.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PATH := build/python/bin:$(PATH)
 VERSION = $(shell python setup.py --version)
 ALLFILES = $(shell echo bottle.py test/*.py test/views/*.tpl)
 
-.PHONY: release coverage install docs test test_all test_26 test_27 test_32 test_33 test_34 test_35 2to3 clean
+.PHONY: release coverage install docs test test_all test_27 test_32 test_33 test_34 test_35 2to3 clean
 
 release: test_all
 	python setup.py --version | egrep -q -v '[a-zA-Z]' # Fail on dev/rc versions
@@ -32,10 +32,7 @@ docs:
 test:
 	python test/testall.py
 
-test_all: test_26 test_27 test_32 test_33 test_34 test_35
-
-test_26:
-	python2.6 test/testall.py
+test_all: test_27 test_32 test_33 test_34 test_35
 
 test_27:
 	python2.7 test/testall.py

--- a/bottle.py
+++ b/bottle.py
@@ -124,7 +124,6 @@ except ImportError:  # pragma: no cover
 
 py = sys.version_info
 py3k = py >= (3, 0, 0)
-py25 = py <  (2, 6, 0)
 py31 = (3, 1, 0) <= py < (3, 2, 0)
 
 # Workaround for the missing "as" keyword in py3k.

--- a/bottle.py
+++ b/bottle.py
@@ -170,21 +170,13 @@ else:  # 2.x
     from StringIO import StringIO as BytesIO
     from ConfigParser import SafeConfigParser as ConfigParser, \
                              Error as ConfigParserError
-    if py25:
-        from UserDict import DictMixin
-
-        def next(it):
-            return it.next()
-
-        bytes = str
-    else:  # 2.6, 2.7
-        from collections import MutableMapping as DictMixin
+    from collections import MutableMapping as DictMixin
     unicode = unicode
     json_loads = json_lds
     eval(compile('def _raise(*a): raise a[0], a[1], a[2]', '<py3fix>', 'exec'))
 
-if py25 or py31:
-    msg = "Python 2.5 and 3.1 support will be dropped in future versions of Bottle."
+if py31:
+    msg = "Python 3.1 support will be dropped in future versions of Bottle."
     warnings.warn(msg, DeprecationWarning)
 
 # Some helpers for string/byte handling

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,26 @@
+test:
+  override:
+    - pyenv versions
+    - pyenv shell 2.7.3; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 2.7.4; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 2.7.5; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 2.7.6; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 2.7.7; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 2.7.8; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 2.7.9; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 2.7.10; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 3.1.5; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 3.2; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 3.2.5; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 3.3.0; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 3.3.2; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 3.3.3; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 3.4.0; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 3.4.1; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 3.4.2; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 3.4.3; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell 3.5.0; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell pypy-2.2.1; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell pypy-2.3.1; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell pypy-2.4.0; eval "$(pyenv init -)"; python --version; python test/testall.py
+    - pyenv shell pypy-2.5.0; eval "$(pyenv init -)"; python --version; python test/testall.py

--- a/docs/_locale/_pot/api.pot
+++ b/docs/_locale/_pot/api.pot
@@ -934,7 +934,7 @@ msgid "limit the cookie to HTTPS connections (default: off)."
 msgstr ""
 
 #: ../../../bottle.py:docstring of bottle.BaseResponse.set_cookie:17
-msgid "prevents client-side javascript to read this cookie (default: off, requires Python 2.6 or newer)."
+msgid "prevents client-side javascript to read this cookie (default: off, requires Python 2.7 or newer)."
 msgstr ""
 
 #: ../../../bottle.py:docstring of bottle.BaseResponse.set_cookie:20

--- a/docs/_locale/_pot/index.pot
+++ b/docs/_locale/_pot/index.pot
@@ -53,7 +53,7 @@ msgid "Download and Install"
 msgstr ""
 
 #: ../../index.rst:49
-msgid "Install the latest stable release with ``pip install bottle``, ``easy_install -U bottle`` or download `bottle.py`__ (unstable) into your project directory. There are no hard [1]_ dependencies other than the Python standard library. Bottle runs with **Python 2.6+ and 3.2+**."
+msgid "Install the latest stable release with ``pip install bottle``, ``easy_install -U bottle`` or download `bottle.py`__ (unstable) into your project directory. There are no hard [1]_ dependencies other than the Python standard library. Bottle runs with **Python 2.7 and 3.2+**."
 msgstr ""
 
 #: ../../index.rst:52

--- a/docs/_locale/_pot/tutorial.pot
+++ b/docs/_locale/_pot/tutorial.pot
@@ -37,7 +37,7 @@ msgid "This will get you the latest development snapshot that includes all the n
 msgstr ""
 
 #: ../../tutorial.rst:47
-msgid "Either way, you'll need Python 2.6 or newer (including 3.2+) to run bottle applications. If you do not have permissions to install packages system-wide or simply don't want to, create a `virtualenv <http://pypi.python.org/pypi/virtualenv>`_ first:"
+msgid "Either way, you'll need Python 2.7 or newer (including 3.2+) to run bottle applications. If you do not have permissions to install packages system-wide or simply don't want to, create a `virtualenv <http://pypi.python.org/pypi/virtualenv>`_ first:"
 msgstr ""
 
 #: ../../tutorial.rst:55
@@ -410,7 +410,7 @@ msgid "**secure:**     Limit the cookie to HTTPS connections (default: off)."
 msgstr ""
 
 #: ../../tutorial.rst:422
-msgid "**httponly:**   Prevent client-side javascript to read this cookie (default: off, requires Python 2.6 or newer)."
+msgid "**httponly:**   Prevent client-side javascript to read this cookie (default: off, requires Python 2.7 or newer)."
 msgstr ""
 
 #: ../../tutorial.rst:424

--- a/docs/_locale/de_DE/LC_MESSAGES/api.po
+++ b/docs/_locale/de_DE/LC_MESSAGES/api.po
@@ -1213,7 +1213,7 @@ msgstr ""
 #: ../../../bottle.pydocstring of bottle.BaseResponse.set_cookie:17
 msgid ""
 "prevents client-side javascript to read this cookie (default: off, requires "
-"Python 2.6 or newer)."
+"Python 2.7 or newer)."
 msgstr ""
 
 #: ../../../bottle.pydocstring of bottle.BaseResponse.set_cookie:20

--- a/docs/_locale/de_DE/LC_MESSAGES/index.po
+++ b/docs/_locale/de_DE/LC_MESSAGES/index.po
@@ -71,7 +71,7 @@ msgid ""
 "Install the latest stable release with ``pip install bottle``, "
 "``easy_install -U bottle`` or download `bottle.py`__ (unstable) into your "
 "project directory. There are no hard [1]_ dependencies other than the Python"
-" standard library. Bottle runs with **Python 2.6+ and 3.2+**."
+" standard library. Bottle runs with **Python 2.7 and 3.2+**."
 msgstr ""
 
 #: ../../index.rst:52

--- a/docs/_locale/de_DE/LC_MESSAGES/tutorial.po
+++ b/docs/_locale/de_DE/LC_MESSAGES/tutorial.po
@@ -56,7 +56,7 @@ msgstr ""
 
 #: ../../tutorial.rst:47
 msgid ""
-"Either way, you'll need Python 2.6 or newer (including 3.2+) to run bottle "
+"Either way, you'll need Python 2.7 or newer (including 3.2+) to run bottle "
 "applications. If you do not have permissions to install packages system-wide"
 " or simply don't want to, create a `virtualenv "
 "<http://pypi.python.org/pypi/virtualenv>`_ first:"
@@ -656,7 +656,7 @@ msgstr ""
 #: ../../tutorial.rst:422
 msgid ""
 "**httponly:**   Prevent client-side javascript to read this cookie (default:"
-" off, requires Python 2.6 or newer)."
+" off, requires Python 2.7 or newer)."
 msgstr ""
 
 #: ../../tutorial.rst:424

--- a/docs/_locale/pt_BR/LC_MESSAGES/_pot/api.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/_pot/api.po
@@ -1190,7 +1190,7 @@ msgstr ""
 #: ../../../bottle.pydocstring of bottle.BaseResponse.set_cookie:17
 msgid ""
 "prevents client-side javascript to read this cookie (default: off, requires "
-"Python 2.6 or newer)."
+"Python 2.7 or newer)."
 msgstr ""
 
 #: ../../../bottle.pydocstring of bottle.BaseResponse.set_cookie:20

--- a/docs/_locale/pt_BR/LC_MESSAGES/_pot/tutorial.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/_pot/tutorial.po
@@ -704,7 +704,7 @@ msgstr ""
 #: ../../tutorial.rst:439
 msgid ""
 "**httponly:**   Prevent client-side javascript to read this cookie (default:"
-" off, requires Python 2.6 or newer)."
+" off, requires Python 2.7 or newer)."
 msgstr ""
 
 #: ../../tutorial.rst:441

--- a/docs/_locale/pt_BR/LC_MESSAGES/api.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/api.po
@@ -1212,7 +1212,7 @@ msgstr ""
 #: ../../../bottle.pydocstring of bottle.BaseResponse.set_cookie:17
 msgid ""
 "prevents client-side javascript to read this cookie (default: off, requires "
-"Python 2.6 or newer)."
+"Python 2.7 or newer)."
 msgstr ""
 
 #: ../../../bottle.pydocstring of bottle.BaseResponse.set_cookie:20

--- a/docs/_locale/pt_BR/LC_MESSAGES/index.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/index.po
@@ -75,8 +75,8 @@ msgid ""
 "Install the latest stable release with ``pip install bottle``, "
 "``easy_install -U bottle`` or download `bottle.py`__ (unstable) into your "
 "project directory. There are no hard [1]_ dependencies other than the Python"
-" standard library. Bottle runs with **Python 2.6+ and 3.2+**."
-msgstr "Instale a última versão estável com ``pip install bottle``, ``easy_install -U bottle`` ou faça o download do `bottle.py`__(instável) dentro do diretório do seu projeto. Não há depedências [1]_ além das bibliotecas padrões do Python. Bottle é compatível com **Python 2.6+ e 3.2+**."
+" standard library. Bottle runs with **Python 2.7 and 3.2+**."
+msgstr "Instale a última versão estável com ``pip install bottle``, ``easy_install -U bottle`` ou faça o download do `bottle.py`__(instável) dentro do diretório do seu projeto. Não há depedências [1]_ além das bibliotecas padrões do Python. Bottle é compatível com **Python 2.7 e 3.2+**."
 
 #: ../../index.rst:52
 msgid "User's Guide"

--- a/docs/_locale/pt_BR/LC_MESSAGES/tutorial.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/tutorial.po
@@ -58,11 +58,11 @@ msgstr "Isso vai te dar o último snapshot de desenvolvimento que inclui todos o
 
 #: ../../tutorial.rst:47
 msgid ""
-"Either way, you'll need Python 2.6 or newer (including 3.2+) to run bottle "
+"Either way, you'll need Python 2.7 or newer (including 3.2+) to run bottle "
 "applications. If you do not have permissions to install packages system-wide"
 " or simply don't want to, create a `virtualenv "
 "<http://pypi.python.org/pypi/virtualenv>`_ first:"
-msgstr "De qualquer maneira, você irá precisar do Python 2.6 ou mais recente (incluindo 3.2+) para executar aplicações bottle. Se você não tem permissões para instalar pacotes globalmente no sistema ou simplesmente não deseja fazer, crie uma `virtualenv <http://pypi.python.org/pypi/virtualenv>`_ primeiro:"
+msgstr "De qualquer maneira, você irá precisar do Python 2.7 ou mais recente (incluindo 3.2+) para executar aplicações bottle. Se você não tem permissões para instalar pacotes globalmente no sistema ou simplesmente não deseja fazer, crie uma `virtualenv <http://pypi.python.org/pypi/virtualenv>`_ primeiro:"
 
 #: ../../tutorial.rst:55
 msgid "Or, if virtualenv is not installed on your system:"
@@ -658,7 +658,7 @@ msgstr ""
 #: ../../tutorial.rst:422
 msgid ""
 "**httponly:**   Prevent client-side javascript to read this cookie (default:"
-" off, requires Python 2.6 or newer)."
+" off, requires Python 2.7 or newer)."
 msgstr ""
 
 #: ../../tutorial.rst:424

--- a/docs/_locale/ru_RU/LC_MESSAGES/api.po
+++ b/docs/_locale/ru_RU/LC_MESSAGES/api.po
@@ -1211,7 +1211,7 @@ msgstr ""
 #: ../../../bottle.pydocstring of bottle.BaseResponse.set_cookie:17
 msgid ""
 "prevents client-side javascript to read this cookie (default: off, requires "
-"Python 2.6 or newer)."
+"Python 2.7 or newer)."
 msgstr ""
 
 #: ../../../bottle.pydocstring of bottle.BaseResponse.set_cookie:20

--- a/docs/_locale/ru_RU/LC_MESSAGES/index.po
+++ b/docs/_locale/ru_RU/LC_MESSAGES/index.po
@@ -71,7 +71,7 @@ msgid ""
 "Install the latest stable release with ``pip install bottle``, "
 "``easy_install -U bottle`` or download `bottle.py`__ (unstable) into your "
 "project directory. There are no hard [1]_ dependencies other than the Python"
-" standard library. Bottle runs with **Python 2.6+ and 3.2+**."
+" standard library. Bottle runs with **Python 2.7 or 3.2+**."
 msgstr ""
 
 #: ../../index.rst:52

--- a/docs/_locale/ru_RU/LC_MESSAGES/tutorial.po
+++ b/docs/_locale/ru_RU/LC_MESSAGES/tutorial.po
@@ -56,7 +56,7 @@ msgstr ""
 
 #: ../../tutorial.rst:47
 msgid ""
-"Either way, you'll need Python 2.6 or newer (including 3.2+) to run bottle "
+"Either way, you'll need Python 2.7 or newer (including 3.2+) to run bottle "
 "applications. If you do not have permissions to install packages system-wide"
 " or simply don't want to, create a `virtualenv "
 "<http://pypi.python.org/pypi/virtualenv>`_ first:"
@@ -656,7 +656,7 @@ msgstr ""
 #: ../../tutorial.rst:422
 msgid ""
 "**httponly:**   Prevent client-side javascript to read this cookie (default:"
-" off, requires Python 2.6 or newer)."
+" off, requires Python 2.7 or newer)."
 msgstr ""
 
 #: ../../tutorial.rst:424

--- a/docs/_locale/zh_CN/LC_MESSAGES/_pot/api.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/_pot/api.po
@@ -1190,7 +1190,7 @@ msgstr ""
 #: ../../../bottle.pydocstring of bottle.BaseResponse.set_cookie:17
 msgid ""
 "prevents client-side javascript to read this cookie (default: off, requires "
-"Python 2.6 or newer)."
+"Python 2.7 or newer)."
 msgstr ""
 
 #: ../../../bottle.pydocstring of bottle.BaseResponse.set_cookie:20

--- a/docs/_locale/zh_CN/LC_MESSAGES/_pot/tutorial.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/_pot/tutorial.po
@@ -704,7 +704,7 @@ msgstr ""
 #: ../../tutorial.rst:439
 msgid ""
 "**httponly:**   Prevent client-side javascript to read this cookie (default:"
-" off, requires Python 2.6 or newer)."
+" off, requires Python 2.7 or newer)."
 msgstr ""
 
 #: ../../tutorial.rst:441

--- a/docs/_locale/zh_CN/LC_MESSAGES/api.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/api.po
@@ -1211,7 +1211,7 @@ msgstr ""
 #: ../../../bottle.pydocstring of bottle.BaseResponse.set_cookie:17
 msgid ""
 "prevents client-side javascript to read this cookie (default: off, requires "
-"Python 2.6 or newer)."
+"Python 2.7 or newer)."
 msgstr ""
 
 #: ../../../bottle.pydocstring of bottle.BaseResponse.set_cookie:20

--- a/docs/_locale/zh_CN/LC_MESSAGES/index.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/index.po
@@ -71,7 +71,7 @@ msgid ""
 "Install the latest stable release with ``pip install bottle``, "
 "``easy_install -U bottle`` or download `bottle.py`__ (unstable) into your "
 "project directory. There are no hard [1]_ dependencies other than the Python"
-" standard library. Bottle runs with **Python 2.6+ and 3.2+**."
+" standard library. Bottle runs with **Python 2.7 and 3.2+**."
 msgstr ""
 
 #: ../../index.rst:52

--- a/docs/_locale/zh_CN/LC_MESSAGES/tutorial.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/tutorial.po
@@ -56,7 +56,7 @@ msgstr "在终端运行以上命令，即可下载到Bottle的最新开发版，
 
 #: ../../tutorial.rst:47
 msgid ""
-"Either way, you'll need Python 2.6 or newer (including 3.2+) to run bottle "
+"Either way, you'll need Python 2.7 or newer (including 3.2+) to run bottle "
 "applications. If you do not have permissions to install packages system-wide"
 " or simply don't want to, create a `virtualenv "
 "<http://pypi.python.org/pypi/virtualenv>`_ first:"
@@ -656,8 +656,8 @@ msgstr "**secure:**     只允许在HTTPS链接中访问cookie (默认: off)"
 #: ../../tutorial.rst:422
 msgid ""
 "**httponly:**   Prevent client-side javascript to read this cookie (default:"
-" off, requires Python 2.6 or newer)."
-msgstr "**httponly:**   防止客户端的javascript读取cookie (默认: off, 要求python 2.6或以上版本)"
+" off, requires Python 2.7 or newer)."
+msgstr "**httponly:**   防止客户端的javascript读取cookie (默认: off, 要求python 2.7或以上版本)"
 
 #: ../../tutorial.rst:424
 msgid ""

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,7 +46,7 @@ Run this script or paste it into a Python console, then point your browser to `<
 
 .. __: https://github.com/bottlepy/bottle/raw/master/bottle.py
 
-Install the latest stable release with ``pip install bottle``, ``easy_install -U bottle`` or download `bottle.py`__ (unstable) into your project directory. There are no hard [1]_ dependencies other than the Python standard library. Bottle runs with **Python 2.6+ and 3.2+**.
+Install the latest stable release with ``pip install bottle``, ``easy_install -U bottle`` or download `bottle.py`__ (unstable) into your project directory. There are no hard [1]_ dependencies other than the Python standard library. Bottle runs with **Python 2.7 and 3.2+**.
 
 User's Guide
 ===============

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -44,7 +44,7 @@ This will get you the latest development snapshot that includes all the new feat
     $ sudo easy_install bottle             # alternative without pip
     $ sudo apt-get install python-bottle   # works for debian, ubuntu, ...
 
-Either way, you'll need Python 2.6 or newer (including 3.2+) to run bottle applications. If you do not have permissions to install packages system-wide or simply don't want to, create a `virtualenv <http://pypi.python.org/pypi/virtualenv>`_ first:
+Either way, you'll need Python 2.7 or newer (including 3.2+) to run bottle applications. If you do not have permissions to install packages system-wide or simply don't want to, create a `virtualenv <http://pypi.python.org/pypi/virtualenv>`_ first:
 
 .. code-block:: bash
 
@@ -419,7 +419,7 @@ The :meth:`Response.set_cookie` method accepts a number of additional keyword ar
 * **domain:**     The domain that is allowed to read the cookie. (default: current domain)
 * **path:**       Limit the cookie to a given path (default: ``/``)
 * **secure:**     Limit the cookie to HTTPS connections (default: off).
-* **httponly:**   Prevent client-side javascript to read this cookie (default: off, requires Python 2.6 or newer).
+* **httponly:**   Prevent client-side javascript to read this cookie (default: off, requires Python 2.7 or newer).
 
 If neither `expires` nor `max_age` is set, the cookie expires at the end of the browser session or as soon as the browser window is closed. There are some other gotchas you should consider when using cookies:
 

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ try:
 except ImportError:
     from distutils.core import setup
 
-if sys.version_info < (2, 6):
-    raise NotImplementedError("Sorry, you need at least Python 2.6 or Python 3.2+ to use bottle.")
+if sys.version_info < (2, 7):
+    raise NotImplementedError("Sorry, you need at least Python 2.7 or Python 3.2+ to use bottle.")
 
 import bottle
 
@@ -32,8 +32,6 @@ setup(name='bottle',
                    'Topic :: Internet :: WWW/HTTP :: WSGI :: Middleware',
                    'Topic :: Internet :: WWW/HTTP :: WSGI :: Server',
                    'Topic :: Software Development :: Libraries :: Application Frameworks',
-                   'Programming Language :: Python :: 2.5',
-                   'Programming Language :: Python :: 2.6',
                    'Programming Language :: Python :: 2.7',
                    'Programming Language :: Python :: 3',
                    'Programming Language :: Python :: 3.2',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py27-most
+envlist = py27,py32,py33,py27-most
 
 [testenv]
 deps=Mako


### PR DESCRIPTION
We are almost 2 years after end of life ...

PEP-361:
Oct 29 2013: Python 2.6.9 final released (security-only)

Python 2.6 should be removed, really. 