### PR TITLE
More Python 2.6\3.0 clean up

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,6 +48,7 @@ Thanks to all the people who found bugs, sent patches, spread the word, helped e
 * Michael Soulier
 * `reddit <http://reddit.com/r/python>`_
 * Nicolas Vanhoren
+* Oz N Tiram
 * Robert Rollins
 * rogererens
 * rwxrwx

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ test_35:
 	python3.5 test/testall.py
 
 test_setup:
-	bash test/build_python.sh 2.6 build/python
 	bash test/build_python.sh 2.7 build/python
 	bash test/build_python.sh 3.2 build/python
 	bash test/build_python.sh 3.3 build/python

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Download and Install
 
 .. __: https://github.com/bottlepy/bottle/raw/master/bottle.py
 
-Install the latest stable release with ``pip install bottle``, ``easy_install -U bottle`` or download `bottle.py`__ (unstable) into your project directory. There are no hard dependencies other than the Python standard library. Bottle runs with **Python 2.6+ and 3.2+**.
+Install the latest stable release with ``pip install bottle``, ``easy_install -U bottle`` or download `bottle.py`__ (unstable) into your project directory. There are no hard dependencies other than the Python standard library. Bottle runs with **Python 2.7 and 3.2+**.
 
 
 License

--- a/bottle.py
+++ b/bottle.py
@@ -119,11 +119,8 @@ except ImportError:  # pragma: no cover
 
             json_lds = json_dumps
 
-# We now try to fix 2.5/2.6/3.1/3.2 incompatibilities.
-# It ain't pretty but it works... Sorry for the mess.
+py3k =  sys.version_info.major > 2
 
-py = sys.version_info
-py3k = py >= (3, 0, 0)
 
 # Workaround for the missing "as" keyword in py3k.
 def _e():

--- a/bottle.py
+++ b/bottle.py
@@ -13,7 +13,6 @@ Copyright (c) 2015, Marcel Hellkamp.
 License: MIT (see LICENSE for details)
 """
 
-from __future__ import with_statement
 import sys
 
 __author__ = 'Marcel Hellkamp'

--- a/bottle.py
+++ b/bottle.py
@@ -4182,7 +4182,7 @@ if __name__ == '__main__':
                     config.load_dict(json_loads(fp.read()))
             else:
                 config.load_config(cfile)
-        except ConfigParserError:
+        except configparser.Error:
             _cli_error(str(_e()))
         except IOError:
             _cli_error("Unable to read config file %r" % cfile)


### PR DESCRIPTION
HI Marcel, 

I removed some more old deprecated code which is no longer needed..

Also, this https://github.com/bottlepy/bottle/blob/master/bottle.py#L130
can also be removed, since all supported versions have this key word.

All https://hg.python.org/cpython/file/3.{2,3,4,5}/Lib/keyword.py have `as`.

Finally, can you give a hint when is Version to be released 0.13?