### PR TITLE
raise HTTPResponse not working correctly

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1923,8 +1923,6 @@ class JSONPlugin(object):
         def wrapper(*a, **ka):
             try:
                 rv = callback(*a, **ka)
-            except HTTPError as error:
-                rv = error
             except HTTPResponse as resp:
                 rv = resp
 

--- a/bottle.py
+++ b/bottle.py
@@ -1925,6 +1925,8 @@ class JSONPlugin(object):
                 rv = callback(*a, **ka)
             except HTTPError as error:
                 rv = error
+            except HTTPResponse as resp:
+                rv = resp
 
             if isinstance(rv, dict):
                 #Attempt to serialize, raises exception on failure


### PR DESCRIPTION
does not return the same results by making "raise" and "return"

```python
from bottle import run, get, HTTPResponse


@get('/test1')
def test1():
    return HTTPResponse({'test': 'ko'}, 402)

@get('/test2')
def test2():
    raise HTTPResponse({'test': 'ko2'}, 402)

run(host='0.0.0.0', port=9988)
```


bottle 0.12.9 results:

```
In [1]: import requests

In [2]: r = requests.get('http://localhost:9988/test1')

In [3]: r.text, r.headers['content-type']
Out[3]: ('{"test": "ko"}', 'application/json')

In [4]: r = requests.get('http://localhost:9988/test2')

In [5]: r.text, r.headers['content-type']
Out[5]: ('test', 'text/html; charset=UTF-8')

```

patch results:

```
In [1]: import requests

In [2]: r = requests.get('http://localhost:9988/test1')

In [3]: r.text, r.headers['content-type']
Out[3]: ('{"test": "ko"}', 'application/json')

In [4]: r = requests.get('http://localhost:9988/test2')

In [5]: r.text, r.headers['content-type']
Out[5]: ('{"test": "ko2"}', 'application/json')

```
