### PR TITLE
Handle unprintable errors

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -4112,7 +4112,12 @@ ERROR_PAGE_TEMPLATE = """
             <pre>{{e.body}}</pre>
             %%if DEBUG and e.exception:
               <h2>Exception:</h2>
-              <pre>{{repr(e.exception)}}</pre>
+              %%try:
+                %%exc = repr(e.exception)
+              %%except:
+                %%exc = '<unprintable %%s object>' %% type(e.exception).__name__
+              %%end
+              <pre>{{exc}}</pre>
             %%end
             %%if DEBUG and e.traceback:
               <h2>Traceback:</h2>


### PR DESCRIPTION
Previously, these would throw another error and obliterate the useful traceback, replacing it with a useless one