### PR TITLE
Static file multithreading

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2835,7 +2835,9 @@ def static_file(filename, root,
         if check and check == etag:
             return HTTPResponse(status=304, **headers)
 
-    ims = getenv('HTTP_IF_MODIFIED_SINCE')
+    ims = request.get_header('If-Modified-Since')
+    if not ims:
+        ims = request.environ.get('HTTP_IF_MODIFIED_SINCE')
     if ims:
         ims = parse_date(ims.split(";")[0].strip())
     if ims is not None and ims >= int(stats.st_mtime):


### PR DESCRIPTION
Context: When I use `bottle.run(..., server='cherrypy')`, I run it in
multi-threaded mode. This results in two requests sharing the same
environment.
They serve the old file with 200 in this case.
Fix: Getting the header from the request object first, makes the actual
request being used and not the request that runs in parallel.
Evaluation: This results in a performance improvement in this scenario,
since one more file is reported as not modified.