### PR TITLE
Fixed issue #911

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -668,7 +668,7 @@ class Bottle(object):
     catchall = DictProperty('config', 'catchall')
 
     __hook_names = 'before_request', 'after_request', 'app_reset', 'config'
-    __hook_reversed = 'after_request'
+    __hook_reversed = {'after_request'}
 
     @cached_property
     def _hooks(self):


### PR DESCRIPTION
Changed __hook_reversed into set.

Set literal is chosen (over list, tuple) because:
1. It is supported since python 2.7, which is the
   lowest version of python supported by bottle
   right now.
2. Set membership testing is fast.
3. Duplicates prevented.