### PR TITLE
Receiving a code other than 2xx generate exception

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -101,11 +101,11 @@ Example using `WebTest <http://webtest.pythonpaste.org/>`_ and `Nose <http://rea
 
         assert app.get('/admin').status == '200 OK'        # fetch a page successfully
 
-        app.get('/logout')                                 # log out
+        assert app.get('/logout').status_code = 200        # log out
         app.reset()                                        # drop the cookie
 
         # fetch the same page, unsuccessfully
-        assert app.get('/admin').status == '401 Unauthorized'
+        assert app.get('/admin', expect_errors=True).status == '401 Unauthorized'
 
 
 Embedding other WSGI Apps


### PR DESCRIPTION
expect_errors=True not generate exception for "bad requests" ( status != 200)
I have checked /logout only with number