### PR TITLE
Add ServerAdapter (fix CherryPy ServerAdapter)

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3255,8 +3255,8 @@ class CherryPyServer(ServerAdapter):
             server.stop()
 
 
-class CherootServer(bottle.ServerAdapter):
-    def run(self, handler):
+class CherootServer(ServerAdapter):
+    def run(self, handler): # pragma: no cover
         from cheroot import wsgi
         from cheroot.ssl import builtin
         self.options['bind_addr'] = (self.host, self.port)


### PR DESCRIPTION
Since CherryPy >= 9, the server part of CherryPy has been extracted and named Cheroot. Thus the old CherryPy ServerAdapter does not work for CherryPy >= 9: The import fails, and the SSL part should be different too. Cheroot can be installed (pip install cheroot) without CherryPy so that we can have a CherootServer adapter in addition to the CherryPyServer adapter for the older versions. I have used this class (just inheriting from bottle.ServerAdapter) and it worked for SSL and non-SSL.

(Edit:) To be clear: The proposed CherootServer adapter is foremost a fix of the CherryPyServer Adapter for the latest versions of CherryPy: When I pip install cherrypy, the cheroot server is installed along with cherrypy, and the imports are working as given in the proposed Adapter (as well as the SSL part). So one could also replace the body of the CherryPyServer adapter with the body of the proposed adapter, calling this adapter either still "CherryPyServer" or "CherootServer".
(Edit 2): Cp. [http://docs.cherrypy.org/en/latest/history.html](http://docs.cherrypy.org/en/latest/history.html)