### PR TITLE
Support ujson

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -77,7 +77,11 @@ from datetime import date as datedate, datetime, timedelta
 from tempfile import TemporaryFile
 from traceback import format_exc, print_exc
 from unicodedata import normalize
-from json import dumps as json_dumps, loads as json_lds
+
+try:
+    from ujson import dumps as json_dumps, loads as json_lds
+except ImportError:
+    from json import dumps as json_dumps, loads as json_lds
 
 # inspect.getargspec was removed in Python 3.6, use
 # Signature-based version where we can (Python 3.3+)


### PR DESCRIPTION
# ujson
Running 2s test @ http://172.17.0.1:8080/
  2 threads and 600 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   141.65ms  322.13ms   1.95s    90.33%
    Req/Sec     6.73k     2.94k   11.84k    60.00%
  26819 requests in 2.02s, 4.42MB read
Requests/sec:  **13257.19**
Transfer/sec:      2.19MB

# json
Running 2s test @ http://172.17.0.1:8080/
  2 threads and 600 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    55.01ms   95.84ms 888.11ms   92.93%
    Req/Sec     5.95k     3.52k   13.20k    75.00%
  23684 requests in 2.01s, 3.93MB read
Requests/sec:  **11762.51**
Transfer/sec:      1.95MB


code benchmark:
```python
from bottle import get, run

@get('/')
def bench():
    return {'hello': 'world'}

run(host='0.0.0.0', port=8080, server='gunicorn', worker_class='egg:meinheld#gunicorn_worker', quiet=True, debug=False)
```