### PR TITLE
conn > con in tutorial app

### DIFF
--- a/docs/tutorial_app.rst
+++ b/docs/tutorial_app.rst
@@ -68,13 +68,13 @@ As we use SQLite3 as a database, make sure it is installed. On Linux systems, mo
 First, we need to create the database we use later on. To do so, save the following script in your project directory and run it with python. You can use the interactive interpreter too::
 
     import sqlite3
-    con = sqlite3.connect('todo.db') # Warning: This file is created in the current directory
-    con.execute("CREATE TABLE todo (id INTEGER PRIMARY KEY, task char(100) NOT NULL, status bool NOT NULL)")
-    con.execute("INSERT INTO todo (task,status) VALUES ('Read A-byte-of-python to get a good introduction into Python',0)")
-    con.execute("INSERT INTO todo (task,status) VALUES ('Visit the Python website',1)")
-    con.execute("INSERT INTO todo (task,status) VALUES ('Test various editors for and check the syntax highlighting',1)")
-    con.execute("INSERT INTO todo (task,status) VALUES ('Choose your favorite WSGI-Framework',0)")
-    con.commit()
+    conn = sqlite3.connect('todo.db') # Warning: This file is created in the current directory
+    conn.execute("CREATE TABLE todo (id INTEGER PRIMARY KEY, task char(100) NOT NULL, status bool NOT NULL)")
+    conn.execute("INSERT INTO todo (task,status) VALUES ('Read A-byte-of-python to get a good introduction into Python',0)")
+    conn.execute("INSERT INTO todo (task,status) VALUES ('Visit the Python website',1)")
+    conn.execute("INSERT INTO todo (task,status) VALUES ('Test various editors for and check the syntax highlighting',1)")
+    conn.execute("INSERT INTO todo (task,status) VALUES ('Choose your favorite WSGI-Framework',0)")
+    conn.commit()
 
 This generates a database-file `todo.db` with tables called ``todo`` and three columns ``id``, ``task``, and ``status``. ``id`` is a unique id for each row, which is used later on to reference the rows. The column ``task`` holds the text which describes the task, it can be max 100 characters long. Finally, the column ``status`` is used to mark a task as open (value 1) or closed (value 0).
 


### PR DESCRIPTION
Every sql connection is abbreviated to `conn` except for the very first `con`. Changed everything to `conn` for consistency.