### PR TITLE
Update wget download instructions to use HTTPS for security

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -34,7 +34,7 @@ Bottle does not depend on any external libraries. You can just download `bottle.
 
 .. code-block:: bash
 
-    $ wget http://bottlepy.org/bottle.py
+    $ wget https://bottlepy.org/bottle.py
 
 This will get you the latest development snapshot that includes all the new features. If you prefer a more stable environment, you should stick with the stable releases. These are available on `PyPI <http://pypi.python.org/pypi/bottle>`_ and can be installed via :command:`pip` (recommended), :command:`easy_install` or your package manager:
 


### PR DESCRIPTION
This affords at least some assurance that what you download is indeed Bottle.