### PR TITLE
"SameSite" cookie feature (from issue #982)

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -420,7 +420,7 @@ The :meth:`Response.set_cookie` method accepts a number of additional keyword ar
 * **path:**       Limit the cookie to a given path (default: ``/``)
 * **secure:**     Limit the cookie to HTTPS connections (default: off).
 * **httponly:**   Prevent client-side javascript to read this cookie (default: off, requires Python 2.7 or newer).
-* **same_site:**  Disables third-party use for a cookie. Allowed attributes: `lax` and `strict`.
+* **same_site:**  Disables third-party use for a cookie. Allowed attributes: `lax` and `strict`. In strict mode the cookie will never be sent. In lax mode the cookie is only sent with a top-level GET request.
 
 If neither `expires` nor `max_age` is set, the cookie expires at the end of the browser session or as soon as the browser window is closed. There are some other gotchas you should consider when using cookies:
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -420,6 +420,9 @@ The :meth:`Response.set_cookie` method accepts a number of additional keyword ar
 * **path:**       Limit the cookie to a given path (default: ``/``)
 * **secure:**     Limit the cookie to HTTPS connections (default: off).
 * **httponly:**   Prevent client-side javascript to read this cookie (default: off, requires Python 2.7 or newer).
+* **same_site:**  Disables third-party use for a cookie. Allowed attributes: `lax` and `strict`.
+                  In strict mode the cookie will never be sent.
+                  In lax mode the cookie is only sent with a top-level GET request.
 
 If neither `expires` nor `max_age` is set, the cookie expires at the end of the browser session or as soon as the browser window is closed. There are some other gotchas you should consider when using cookies:
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -421,8 +421,6 @@ The :meth:`Response.set_cookie` method accepts a number of additional keyword ar
 * **secure:**     Limit the cookie to HTTPS connections (default: off).
 * **httponly:**   Prevent client-side javascript to read this cookie (default: off, requires Python 2.7 or newer).
 * **same_site:**  Disables third-party use for a cookie. Allowed attributes: `lax` and `strict`.
-                  In strict mode the cookie will never be sent.
-                  In lax mode the cookie is only sent with a top-level GET request.
 
 If neither `expires` nor `max_age` is set, the cookie expires at the end of the browser session or as soon as the browser window is closed. There are some other gotchas you should consider when using cookies:
 


### PR DESCRIPTION
As mentioned in #982, `set_cookie()` does not support  the "SameSite" cookie attribute.
This is because the `http.cookies` module doesn't support that either.
A reason for _this_ isn't really given. It's just that the module was based on RFC 2109 which "SameSite" is not a part of.
In the python repository changes have been made and a pull request opened (python/cpython#214) so that `http.cookies` could eventually support "SameSite" natively in 3.7.

However, since this is future stuff it doesn't really make a difference for bottle at the moment and i've come to the conclusion that it would be feature that's nice to have.

So i've added this feature to bottle, and updated the docs.

It doesn't to much, i just import the `_reserved` dict in which valid attributes for cookies are stored,
`set_cookie()` now supports the keyword `same_site` and ` raises a `CookieError` if the value for `same_site` isn't `strict` or `lax`.

This mimics petty much what the requested change for `http.cookies` in 3.7 would do. 

