### PR TITLE
Fix CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: required
 python:
   - "2.7.3" # Ubuntu 12.4LTS (precise) and Debian 7 LTS (wheezy)
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"

--- a/README.rst
+++ b/README.rst
@@ -13,11 +13,7 @@
 
 .. image:: https://coveralls.io/repos/github/bottlepy/bottle/badge.svg?branch=master
    :target: https://coveralls.io/github/bottlepy/bottle?branch=master
-   :alt: Coverage 
-
-.. image:: https://img.shields.io/pypi/dm/bottle.svg
-    :target: https://pypi.python.org/pypi/bottle/
-    :alt: Downloads
+   :alt: Coverage
 
 .. image:: https://img.shields.io/pypi/v/bottle.svg
     :target: https://pypi.python.org/pypi/bottle/

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,6 @@ test:
     - pyenv versions
     - pyenv shell 2.7.3; eval "$(pyenv init -)"; python --version; python test/testall.py fast
     - pyenv shell 2.7; eval "$(pyenv init -)"; python --version; python test/testall.py fast
-    - pyenv shell 3.2; eval "$(pyenv init -)"; python --version; python test/testall.py fast
     - pyenv shell 3.3-dev; eval "$(pyenv init -)"; python --version; python test/testall.py fast
     - pyenv shell 3.4-dev; eval "$(pyenv init -)"; python --version; python test/testall.py fast
     - pyenv shell 3.5-dev; eval "$(pyenv init -)"; python --version; python test/testall.py fast


### PR DESCRIPTION
@defnull I removed Python 3.2 version because they break the build. 
Also, this version of Python is obsolete and it should cause people to think bottle in it's
current master branch is not working with their current Python (I assume most people 
will not have Python 3.2).