### PR TITLE
Explicitly add global variables to the globals dictionary passed to exec statement when executing compiled templates.

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3972,6 +3972,7 @@ class SimpleTemplate(BaseTemplate):
     def execute(self, _stdout, kwargs):
         env = self.defaults.copy()
         env.update(kwargs)
+        env.update(globals())
         env.update({
             '_stdout': _stdout,
             '_printlist': _stdout.extend,


### PR DESCRIPTION
SimpleTemeplate is implemented as a compiled python code object executed using the builtin function exec(). The global variables visible in the compiled statement are passed as a dictionary. This dictionary now contains explicitly all definitions of the global context, in which exec() is called. Otherwise, specifying a variable in the URL pattern called \_\_builtins\_\_ leads to an empty globals() context, because exec() would not add the globals() definitions implicitly in that case. All calls of builtins in the compiled statement would lead to an exception.
See https://docs.python.org/3/library/functions.html#exec for the implicit definition of necessary global context.