### PR TITLE
Fix Last-Modifed and Date header formats in static_file for non-engli…

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2884,9 +2884,9 @@ def static_file(filename, root,
 
     stats = os.stat(filename)
     headers['Content-Length'] = clen = stats.st_size
-    lm = time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(stats.st_mtime))
-    headers['Last-Modified'] = lm
-    headers['Date'] = time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime())
+    headers['Last-Modified'] = email.utils.formatdate(stats.st_mtime,
+                                                      usegmt=True)
+    headers['Date'] = email.utils.formatdate(time.time(), usegmt=True)
 
     getenv = request.environ.get
 


### PR DESCRIPTION
…sh locales

time.strftime produces locale-dependent date format. At best, this lead to
invalid dates being produced, e. g: 'Ne, 05 lis 2017 12:58:28 GMT'. At worst,
this lead to encoding crashes for dates like 'Út, 31 říj 2017 12:58:28 GMT'

Some code to reproduce the issue

```
#! /usr/bin/env python3

import locale
import os
import bottle
import time

locale.setlocale(locale.LC_TIME, "cs_CZ.UTF-8")

print(time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime()))


@bottle.route("/<path:path>")
def handle(path):
    return bottle.static_file(path, root=os.path.dirname(__file__))

bottle.run(host="localhost", port="9999")
```

(wait for tuesday to get it to crash :))