### PR TITLE
Add UnicodeFormsPlugin + tests

### DIFF
--- a/test/test_formsdict.py
+++ b/test/test_formsdict.py
@@ -6,18 +6,18 @@ from bottle import FormsDict, touni, tob
 
 class TestFormsDict(unittest.TestCase):
     def test_attr_access(self):
-        """ FomsDict.attribute returs string values as unicode. """
+        """ FormsDict.attribute returns string values as unicode. """
         d = FormsDict(py2=tob('瓶'), py3=tob('瓶').decode('latin1'))
         self.assertEqual(touni('瓶'), d.py2)
         self.assertEqual(touni('瓶'), d.py3)
 
     def test_attr_missing(self):
-        """ FomsDict.attribute returs u'' on missing keys. """
+        """ FormsDict.attribute returns u'' on missing keys. """
         d = FormsDict()
         self.assertEqual(touni(''), d.missing)
 
     def test_attr_unicode_error(self):
-        """ FomsDict.attribute returs u'' on UnicodeError. """
+        """ FormsDict.attribute returns u'' on UnicodeError. """
         d = FormsDict(latin=touni('öäüß').encode('latin1'))
         self.assertEqual(touni(''), d.latin)
         d.input_encoding = 'latin1'

--- a/test/test_unicodeformsdict.py
+++ b/test/test_unicodeformsdict.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# '瓶' means "Bottle"
+
+import unittest
+from bottle import UnicodeFormsDict, FormsDict, touni, tob
+
+class TestUnicodeFormsDict(unittest.TestCase):
+    def test_attr_access(self):
+        """ UnicodeFormsDict.attribute returns string values as unicode. """
+        d = UnicodeFormsDict(py2=tob('瓶'), py3=tob('瓶').decode('latin1'))
+        self.assertEqual(touni('瓶'), d.py2)
+        self.assertEqual(touni('瓶'), d.py3)
+
+    def test_attr_missing(self):
+        """ UnicodeFormsDict.attribute returns u'' on missing keys. """
+        d = UnicodeFormsDict()
+        self.assertEqual(touni(''), d.missing)
+
+    def test_attr_unicode_error(self):
+        """ UnicodeFormsDict.attribute returns u'' on UnicodeError. """
+        d = UnicodeFormsDict(latin=touni('öäüß').encode('latin1'))
+        self.assertEqual(touni(''), d.latin)
+        d.input_encoding = 'latin1'
+        self.assertEqual(touni('öäüß'), d.latin)
+
+    def test_dict_access(self):
+        """ UnicodeFormsDict[direct_access] returns string values as unicode. """
+        d = UnicodeFormsDict(py2=tob('瓶'), py3=tob('瓶').decode('latin1'))
+        self.assertEqual(touni('瓶'), d['py2'])
+        self.assertEqual(touni('瓶'), d['py3'])
+    
+    def test_get_access(self):
+        """ UnicodeFormsDict returns value strings as unicode in all relevent methods. """
+        d = UnicodeFormsDict(py2=tob('瓶'), py3=tob('瓶').decode('latin1'))
+        self.assertTrue(hasattr(d.get('py2'), 'encode'))
+        self.assertTrue(hasattr(d.getunicode('py2'), 'encode'))
+        self.assertTrue(hasattr(list(d.values())[0], 'encode'))
+        self.assertTrue(hasattr(list(d.items())[0][1], 'encode'))
+        self.assertTrue(hasattr(list(d.allitems())[0][1], 'encode'))
+    
+    def test_raw_access(self):
+        """ UnicodeFormsDict returns raw strings in relevent methods with proper kwargs. """
+        d = UnicodeFormsDict(py2=tob('瓶'), py3=tob('瓶').decode('latin1'))
+        self.assertEqual(d.get('py2', raw=True), tob('瓶'))
+        self.assertEqual(d.get('py3', raw=True), tob('瓶').decode('latin1'))
+        self.assertEqual(d.get('py2'), '瓶')
+        self.assertEqual(d.get('py3'), '瓶')
+        self.assertEqual(d.getall('py2', raw=True), [tob('瓶')])
+        self.assertEqual(d.getall('py3', raw=True), [tob('瓶').decode('latin1')])
+        self.assertEqual(d.getall('py2'), ['瓶'])
+        self.assertEqual(d.getall('py3'), ['瓶'])
+
+    def test_decode_method(self):
+        d = UnicodeFormsDict(py2=tob('瓶'), py3=tob('瓶').decode('latin1'))
+        d = d.decode()
+        self.assertTrue(isinstance(d, FormsDict))
+        self.assertFalse(d.recode_unicode)
+        self.assertTrue(hasattr(list(d.keys())[0], 'encode'))
+        self.assertTrue(hasattr(list(d.values())[0], 'encode'))


### PR DESCRIPTION
Fixes #774 .

What: Adds a built-in plugin, `UnicodeFormsPlugin`, which looks for `config['utf8.unicode_forms']`. By default, `utf8.unicode_forms` is `False`, which means `FormsDict` will be used. When it is set to `True`, `UnicodeFormsDict` is used which inherits from `FormsDict` and overrides `MultiDict` methods so that all methods use `_fix` when applicable. It still retains access to the raw values through a few methods.

Usage:
```
app = bottle.Bottle()
app.install(bottle.UnicodeFormsPlugin())

app.config['utf8.unicode_forms'] = True
# or
@app.post('/someroute', **{'utf8.unicode_forms' : True})
def myroute():
    pass
```

It is both skippable and configurable per-route.

Since #774 is a compatibility issue, I tried to make sure an easy migration was possible. People can start using this plugin now, it can be turned on by default at a later version, and then we can remove the plugin and change the default behaviour later.