### PR TITLE
fix pass None to tob

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -161,7 +161,7 @@ else:  # 2.x
 def tob(s, enc='utf8'):
     if isinstance(s, unicode):
         return s.encode(enc)
-    return bytes("" if s is None else s)
+    return b'' if s is None else bytes(s)
 
 
 def touni(s, enc='utf8', err='strict'):


### PR DESCRIPTION
I think the `tob` fuction has a bug on this [line](https://github.com/bottlepy/bottle/blob/master/bottle.py#L164)

```Python
def tob(s, enc='utf8'):
    if isinstance(s, unicode):
        return s.encode(enc)
    return bytes("" if s is None else s)
```

If pass `None` to `tob`, it will execute `bytes("")`. And there will be a `TypeError` that `string argument without an encoding`

I think you mean that `return b'' if s is None else bytes(s)`

