### PR TITLE
Fix UnboundLocalError in the ConfigDict load_dict method

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2111,7 +2111,7 @@ class ConfigDict(dict):
         while stack:
             prefix, source = stack.pop()
             if not isinstance(source, dict):
-                raise TypeError('Source is not a dict (r)' % type(key))
+                raise TypeError('Source is not a dict (%r)' % type(source))
             for key, value in source.items():
                 if not isinstance(key, basestring):
                     raise TypeError('Key is not a string (%r)' % type(key))


### PR DESCRIPTION
The error is raised when I try the following code in the interpreter:
```
>>> from bottle import ConfigDict
>>> c = ConfigDict()
>>> c.load_dict(1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "bottle.py", line 2114, in load_dict
    raise TypeError('Source is not a dict (r)' % type(key))
UnboundLocalError: local variable 'key' referenced before assignment
```