### PR TITLE
Fix path_shift fall back always triggering

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -737,7 +737,8 @@ class Bottle(object):
                 body = app(request.environ, start_response)
                 rs.body = itertools.chain(rs.body, body) if rs.body else body
                 return rs
-            finally:
+            except Exception as err:
+                print_exc()
                 request.path_shift(-path_depth)
 
         options.setdefault('skip', True)


### PR DESCRIPTION
Instead of always doing a negative root path shift,
even after a successful return, only catch exceptions.