### PR TITLE
Fix deprecation warning for imp module

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -69,10 +69,10 @@ if __name__ == '__main__':
 # Imports and Python 2/3 unification ##########################################
 ###############################################################################
 
-import base64, calendar, cgi, email.utils, functools, hmac, imp, itertools,\
-       mimetypes, os, re, tempfile, threading, time, warnings, weakref, hashlib
+import os, re, base64, calendar, cgi, email.utils, functools, hmac, itertools,\
+       mimetypes, tempfile, threading, time, warnings, weakref, hashlib
 
-from types import FunctionType
+from types import FunctionType, ModuleType
 from datetime import date as datedate, datetime, timedelta
 from tempfile import TemporaryFile
 from traceback import format_exc, print_exc
@@ -2057,7 +2057,7 @@ class _ImportRedirect(object):
         """ Create a virtual package that redirects imports (see PEP 302). """
         self.name = name
         self.impmask = impmask
-        self.module = sys.modules.setdefault(name, imp.new_module(name))
+        self.module = sys.modules.setdefault(name, ModuleType(name))
         self.module.__dict__.update({
             '__file__': __file__,
             '__path__': [],


### PR DESCRIPTION
## Rationale
This PR addresses #1029 

## Changes
* Fix deprecation warning for `imp` module
* Updated on the recent `master` branch (1/4/22)

## Testing
With 
```
$ python --version
Python 3.6.3
$ pip install bottle==0.12.13
$ python -W default
>>> import bottle
```
to reproduce warning
```
/home/user/.virtualenvs/bottle3.6.3/lib/python3.6/site-packages/bottle.py:38: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
```
Current version doesn't show this warning and tests are passing.