### PR TITLE
Fix resources leak in tests

### DIFF
--- a/test/test_app.py
+++ b/test/test_app.py
@@ -7,6 +7,7 @@
 import unittest
 from bottle import Bottle
 
+
 class TestApplicationObject(unittest.TestCase):
     
     def test_setattr(self):

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -2,9 +2,10 @@
 import bottle
 from tools import ServerTestBase
 
+
 class TestBasicAuth(ServerTestBase):
 
-    def test__header(self):
+    def test_header(self):
         @bottle.route('/')
         @bottle.auth_basic(lambda x, y: False)
         def test(): return {}

--- a/test/test_fileupload.py
+++ b/test/test_fileupload.py
@@ -2,10 +2,11 @@
 ''' Tests for the FileUpload wrapper. '''
 
 import unittest
-import sys, os.path
+import os.path
 import bottle
-from bottle import FileUpload, BytesIO, tob
+from bottle import FileUpload, BytesIO
 import tempfile
+
 
 class TestFileUpload(unittest.TestCase):
     def test_name(self):

--- a/test/test_fileupload.py
+++ b/test/test_fileupload.py
@@ -60,10 +60,16 @@ class TestFileUpload(unittest.TestCase):
         self.assertRaises(IOError, fu.save, __file__)
 
     def test_save_dir(self):
-        fu = FileUpload(open(__file__, 'rb'), 'testfile', __file__)
+        fp = open(__file__, 'rb')
+        fu = FileUpload(fp, 'testfile', __file__)
         dirpath = tempfile.mkdtemp()
         filepath = os.path.join(dirpath, fu.filename)
         fu.save(dirpath)
-        self.assertEqual(fu.file.read(), open(filepath, 'rb').read())
-        os.unlink(filepath)
-        os.rmdir(dirpath)
+        fp_expected = open(filepath, 'rb')
+        try:
+            self.assertEqual(fu.file.read(), fp_expected.read())
+        finally:
+            fp.close()
+            fp_expected.close()
+            os.unlink(filepath)
+            os.rmdir(dirpath)

--- a/test/test_resources.py
+++ b/test/test_resources.py
@@ -73,4 +73,9 @@ class TestResourceManager(unittest.TestCase):
         rm = ResourceManager()
         rm.add_path(__file__)
         fp = rm.open(__file__)
-        self.assertEqual(fp.read(), open(__file__).read())
+        fp_expected = open(__file__)
+        try:
+            self.assertEqual(fp.read(), fp_expected.read())
+        finally:
+            fp.close()
+            fp_expected.close()

--- a/test/test_securecookies.py
+++ b/test/test_securecookies.py
@@ -1,4 +1,4 @@
-#coding: utf-8
+# -*- coding: utf-8 -*-
 import unittest
 
 import bottle
@@ -43,4 +43,5 @@ class TestSignedCookies(unittest.TestCase):
 class TestSignedCookiesWithPickle(TestSignedCookies):
     def setUp(self):
         super(TestSignedCookiesWithPickle, self).setUp()
-        self.data = dict(a=5, b=touni('υηι¢σ∂є'), c=[1,2,3,4,tob('bytestring')])
+        self.data = dict(a=5, b=touni('υηι¢σ∂є'),
+                         c=[1, 2, 3, 4, tob('bytestring')])

--- a/test/test_sendfile.py
+++ b/test/test_sendfile.py
@@ -116,21 +116,32 @@ class TestSendFile(unittest.TestCase):
     def test_etag(self):
         """ SendFile: If-Modified-Since"""
         res = static_file(basename, root=root)
-        self.assertTrue('ETag' in res.headers)
-        self.assertEqual(200, res.status_code)
+        try:
+            self.assertTrue('ETag' in res.headers)
+            self.assertEqual(200, res.status_code)
+        finally:
+            res.close()
+
         etag = res.headers['ETag']
-        
         request.environ['HTTP_IF_NONE_MATCH'] = etag
         res = static_file(basename, root=root)
-        self.assertTrue('ETag' in res.headers)
-        self.assertEqual(etag, res.headers['ETag'])
-        self.assertEqual(304, res.status_code)
+
+        try:
+            self.assertTrue('ETag' in res.headers)
+            self.assertEqual(etag, res.headers['ETag'])
+            self.assertEqual(304, res.status_code)
+        finally:
+            res.close()
 
         request.environ['HTTP_IF_NONE_MATCH'] = etag
         res = static_file(basename2, root=root2)
-        self.assertTrue('ETag' in res.headers)
-        self.assertNotEqual(etag, res.headers['ETag'])
-        self.assertEqual(200, res.status_code)
+
+        try:
+            self.assertTrue('ETag' in res.headers)
+            self.assertNotEqual(etag, res.headers['ETag'])
+            self.assertEqual(200, res.status_code)
+        finally:
+            res.close()
 
     def test_download(self):
         """ SendFile: Download as attachment """

--- a/test/test_sendfile.py
+++ b/test/test_sendfile.py
@@ -106,11 +106,12 @@ class TestSendFile(unittest.TestCase):
         self.assertAlmostEqual(int(time.time()), parse_date(res.headers['Date']))
         request.environ['HTTP_IF_MODIFIED_SINCE'] = time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(100))
         fp = open(__file__, 'rb')
+        sf = static_file(basename, root=root)
         try:
-            self.assertEqual(fp.read(),
-                             static_file(basename, root=root).body.read())
+            self.assertEqual(fp.read(), sf.body.read())
         finally:
             fp.close()
+            sf.close()
 
     def test_etag(self):
         """ SendFile: If-Modified-Since"""

--- a/test/test_sendfile.py
+++ b/test/test_sendfile.py
@@ -48,7 +48,11 @@ class TestSendFile(unittest.TestCase):
     def test_valid(self):
         """ SendFile: Valid requests"""
         out = static_file(basename, root=root)
-        self.assertEqual(open(__file__,'rb').read(), out.body.read())
+        fp = open(__file__, 'rb')
+        try:
+            self.assertEqual(fp.read(), out.body.read())
+        finally:
+            fp.close()
 
     def test_invalid(self):
         """ SendFile: Invalid requests"""
@@ -114,7 +118,8 @@ class TestSendFile(unittest.TestCase):
         request.environ['HTTP_IF_MODIFIED_SINCE'] = time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(100))
 
         f = static_file(basename, root=root)
-        self.assertEqual(open(__file__,'rb').read(), f.body.read())
+        with open(__file__, 'rb') as fp:
+            self.assertEqual(fp.read(), f.body.read())
 
     def test_range(self):
         request.environ['HTTP_RANGE'] = 'bytes=10-25,-80'

--- a/test/testall.py
+++ b/test/testall.py
@@ -6,7 +6,8 @@ import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import test
-print (test.__file__)
+
+print(test.__file__)
 suite = test.suite
 
 if __name__ == '__main__':

--- a/test/tools.py
+++ b/test/tools.py
@@ -37,6 +37,7 @@ class chdir(object):
     def __exit__(self, exc_type, exc_val, tb):
         os.chdir(self.old)
 
+
 class assertWarn(object):
     def __init__(self, text):
         self.searchtext = text
@@ -86,6 +87,7 @@ def wsgistr(s):
         return s.encode('utf8').decode('latin1')
     else:
         return s
+
 
 class ServerTestBase(unittest.TestCase):
     def setUp(self):
@@ -156,6 +158,7 @@ class ServerTestBase(unittest.TestCase):
         err = bottle.request.environ['wsgi.errors'].errors.read()
         if search not in err:
             self.fail('The search pattern "%s" is not included in wsgi.error: %s' % (search, err))
+
 
 def multipart_environ(fields, files):
     boundary = str(uuid.uuid1())


### PR DESCRIPTION
## Rationale
We have a lot of `ResourceWarning: unclosed file <_io.BufferedReader name` due to some files being improperly closed in tests.
This pr ensures that resources is closed after they have been used.

## Changes
* Close opened file descriptors
* Some codestyle fixes