### PR TITLE
Fix for #1048 - Added header options support to set_header()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ MANIFEST
 bottle.egg-info/
 .htmlcoverage/
 docs/_locale/_pot/.doctrees/
+.mypy_cache/
+.tox/

--- a/bottle.py
+++ b/bottle.py
@@ -157,6 +157,7 @@ else:  # 2.x
     json_loads = json_lds
     exec(compile('def _raise(*a): raise a[0], a[1], a[2]', '<py3fix>', 'exec'))
 
+
 # Some helpers for string/byte handling
 def tob(s, enc='utf8'):
     if isinstance(s, unicode):
@@ -1609,6 +1610,23 @@ def _hval(value):
         raise ValueError("Header value must not contain control characters: %r" % value)
     return value
 
+_token_chars = frozenset("!#$%&'*+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+'^_`abcdefghijklmnopqrstuvwxyz|~')
+
+def _hquote(value, extra_chars='', allow_token=True):
+    """Quote a header value if necessary.
+
+       Taken from Werkzeug project http.py module:
+       https://github.com/pallets/werkzeug/blob/master/werkzeug/http.py
+    """
+    value = str(value)
+    if allow_token:
+        token_chars = _token_chars | set(extra_chars)
+    if set(value).issubset(token_chars):
+        return value
+    return '"%s"' % value.replace('\\', '\\\\').replace('"', '\\"')
+
+
 class HeaderProperty(object):
     def __init__(self, name, reader=None, writer=None, default=''):
         self.name, self.default = name, default
@@ -1748,10 +1766,29 @@ class BaseResponse(object):
             header with that name, return a default value. """
         return self._headers.get(_hkey(name), [default])[-1]
 
-    def set_header(self, name, value):
+    def set_header(self, name, value, **options):
         """ Create a new response header, replacing any previously defined
-            headers with the same name. """
-        self._headers[_hkey(name)] = [_hval(value)]
+            headers with the same name.
+
+            Field properties (options are supported) so this:
+
+            set_header("Content-Type", "text/plain", foo="bar")
+
+            ... will result it this:
+
+            "text/plain; foo=bar"
+
+            Options support is heavily inspired by Werkzeug project. In fact
+            it's almost a complete rip-off of quote_header_value() from http.py
+            module.
+        """
+        segments = [_hval(value)]
+        for k, v in options.items():
+            if v in None:
+                segments.append(k)
+            else:
+                segments.append('%s=%s' % (k, _hquote(_hval(v))))
+        self._headers[_hkey(name)] = ['; '.join(segments)]
 
     def add_header(self, name, value):
         """ Add an additional response header, not removing duplicates. """

--- a/bottle.py
+++ b/bottle.py
@@ -157,7 +157,6 @@ else:  # 2.x
     json_loads = json_lds
     exec(compile('def _raise(*a): raise a[0], a[1], a[2]', '<py3fix>', 'exec'))
 
-
 # Some helpers for string/byte handling
 def tob(s, enc='utf8'):
     if isinstance(s, unicode):
@@ -1783,7 +1782,9 @@ class BaseResponse(object):
             module.
         """
         segments = [_hval(value)]
-        for k, v in options.items():
+        # Sort to ensure joining is always idempotent
+        for k in sorted(options.keys()):
+            v = options[k]
             if v is None:
                 segments.append(k)
             else:

--- a/bottle.py
+++ b/bottle.py
@@ -1784,7 +1784,7 @@ class BaseResponse(object):
         """
         segments = [_hval(value)]
         for k, v in options.items():
-            if v in None:
+            if v is None:
                 segments.append(k)
             else:
                 segments.append('%s=%s' % (k, _hquote(_hval(v))))

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -291,22 +291,20 @@ The ordering of this list is significant. You may for example return a subclass 
 
 .. rubric:: Changing the Default Encoding
 
-Bottle uses the `charset` parameter of the ``Content-Type`` header to decide how to encode unicode strings. This header defaults to ``text/html; charset=UTF8`` and can be changed using the :attr:`Response.content_type` attribute or by setting the :attr:`Response.charset` attribute directly. (The :class:`Response` object is described in the section :ref:`tutorial-response`.)
+Bottle uses the `charset` parameter of the ``Content-Type`` header to decide how to encode unicode strings. This header defaults to ``text/html; charset=UTF8`` and can be changed using the :attr:`Response.content_type` attribute or by passing additional parameters to :func:`Response.set_header`. (The :class:`Response` object is described in the section :ref:`tutorial-response`.)
 
 ::
 
     from bottle import response
     @route('/iso')
     def get_iso():
-        response.charset = 'ISO-8859-15'
+        response.set_header('text/html', charset='ISO-8859-15')
         return u'This will be sent with ISO-8859-15 encoding.'
 
     @route('/latin9')
     def get_latin():
         response.content_type = 'text/html; charset=latin9'
         return u'ISO-8859-15 is also known as latin9.'
-
-In some rare cases the Python encoding names differ from the names supported by the HTTP specification. Then, you have to do both: first set the :attr:`Response.content_type` header (which is sent to the client unchanged) and then set the :attr:`Response.charset` attribute (which is used to encode unicode).
 
 .. _tutorial-static-files:
 
@@ -382,11 +380,17 @@ The `HTTP status code <http_code>`_ controls the behavior of the browser and def
 
 .. rubric:: Response Header
 
-Response headers such as ``Cache-Control`` or ``Location`` are defined via :meth:`Response.set_header`. This method takes two parameters, a header name and a value. The name part is case-insensitive::
+Response headers such as ``Cache-Control`` or ``Location`` are defined via :meth:`Response.set_header`. This method takes two mandatory parameters, a header name and a value. The name part is case-insensitive. Additionally an arbitrary amount of header options (such as ``charset`` etc) can be passed as keyword arguments::
 
   @route('/wiki/<page>')
   def wiki(page):
       response.set_header('Content-Language', 'en')
+      ...
+
+  @rout('/about')
+  def about():
+      # This will produce a header: "Content-Type: text/html; charset=utf-8; foo=bar"
+      response.set_header('Content-Type', 'text/html', charset='utf-8', foo='bar')
       ...
 
 Most headers are unique, meaning that only one header per name is send to the client. Some special headers however are allowed to appear more than once in a response. To add an additional header, use :meth:`Response.add_header` instead of :meth:`Response.set_header`::

--- a/test/test_environ.py
+++ b/test/test_environ.py
@@ -494,7 +494,7 @@ class TestResponse(unittest.TestCase):
     def test_wsgi_header_values(self):
         def cmp(app, wire):
             rs = BaseResponse()
-            rs.set_header('x-test', app)
+            rs.set_header('x-test', app, foo='bar')  # TEST IT PROPERLY
             result = [v for (h, v) in rs.headerlist if h.lower()=='x-test'][0]
             self.assertEquals(wire, result)
 


### PR DESCRIPTION
Fix for #1048 

Most of the credit goes to developers of [Werkzeug](https://github.com/pallets/werkzeug) project as the the code was directly adapted from there. Precisely:

- `bottle._hquote()` adapted from `werkzeug.http.quote_header_value()`
- `bottle.BaseResponse.set_header()` modification borrows a lot from `werkzeug.http.dump_options_header()`

The original problem from #1048 now can be solved like this (as it was suggested by @defnull):
```
response.set_header("Content-Type", "text/plain", charset="not-utf8")
```

Tests were updated and are passing (at least on my host) for Python2.7 and Python3.6.

@defnull please let me know what you want me to change (if anything) so it can be merged.