### PR TITLE
Add the flag in front of the regexp to avoid Deprecation warning

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -4021,7 +4021,7 @@ class StplParser(object):
     # This huge pile of voodoo magic splits python code into 8 different tokens.
     # We use the verbose (?x) regex mode to make this more manageable
 
-    _re_tok = _re_inl = r'''(?mx)(        # verbose and dot-matches-newline mode
+    _re_tok = _re_inl = r'''(
         [urbURB]*
         (?:  ''(?!')
             |""(?!")
@@ -4062,6 +4062,12 @@ class StplParser(object):
     _re_split = r'''(?m)^[ \t]*(\\?)((%(line_start)s)|(%(block_start)s))'''
     # Match inline statements (may contain python strings)
     _re_inl = r'''%%(inline_start)s((?:%s|[^'"\n]+?)*?)%%(inline_end)s''' % _re_inl
+
+    # add the flag in front of the regexp to avoid Deprecation warning (see Issue #949)
+    # verbose and dot-matches-newline mode
+    _re_tok = '(?mx)' + _re_tok
+    _re_inl = '(?mx)' + _re_inl
+
 
     default_syntax = '<% %> % {{ }}'
 


### PR DESCRIPTION
This is a fix for #949 

Bug : With my configuration : (Python 3.6.5rc1 and latest bottle) I see this warning on every page display : 
[Fri Apr 06 10:58:52.502762 2018] [wsgi:error] [pid 17383:tid 140555989333760] [remote 10.0.2.2:40164] /opt/planisware/planibox/py/pb/ext/bottle.py:4088: DeprecationWarning: Flags not at the start of the expression '\\\\{\\\\{((?:(?mx)(      ' (truncated)
[Fri Apr 06 10:58:52.503202 2018] [wsgi:error] [pid 17383:tid 140555989333760] [remote 10.0.2.2:40164]   patterns = [re.compile(p % pattern_vars) for p in patterns]

Fix : I moved the flags in front of the regexp as requested by the Python documentation : https://docs.python.org/3/library/re.html#regular-expression-syntax 

Test : On my configuration, the warning has disappeared and all seems to still be working fine. Let me know if there is automated testing that you want me to run.  
