### PR TITLE
Fix for proper decoding non-latin1 symbols

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2191,7 +2191,11 @@ class FormsDict(MultiDict):
 
     def _fix(self, s, encoding=None):
         if isinstance(s, unicode) and self.recode_unicode:  # Python 3 WSGI
-            return s.encode('latin1').decode(encoding or self.input_encoding)
+            try:
+                s = s.encode('latin1').decode(encoding or self.input_encoding)
+            except UnicodeEncodeError:
+                s = s.encode('utf8').decode(encoding or self.input_encoding)
+            return s
         elif isinstance(s, bytes):  # Python 2 WSGI
             return s.decode(encoding or self.input_encoding)
         else:

--- a/test/test_environ.py
+++ b/test/test_environ.py
@@ -319,7 +319,7 @@ class TestRequest(unittest.TestCase):
 
     def test_multipart(self):
         """ Environ: POST (multipart files and multible values per key) """
-        fields = [('field1','value1'), ('field2','value2'), ('field2','value3')]
+        fields = [('field1','value1'), ('field2','value2'), ('field2','value3'), ('field3','Чебурашка')]
         files = [('file1','filename1.txt','content1'), ('万难','万难foo.py', 'ä\nö\rü')]
         e = tools.multipart_environ(fields=fields, files=files)
         request = BaseRequest(e)
@@ -354,6 +354,8 @@ class TestRequest(unittest.TestCase):
         self.assertEqual(['value2', 'value3'], request.POST.getall('field2'))
         self.assertEqual(['value2', 'value3'], request.forms.getall('field2'))
         self.assertTrue('field2' not in request.files)
+        # Field (multi), test POST.decode() with non-latin1 data
+        request.POST.decode()
 
     def test_json_empty(self):
         """ Environ: Request.json property with empty body. """


### PR DESCRIPTION
If there are cyrillic or other non-latin1 symbols in data in request and there are simultaneously files in request there will be UnicodeEncodeError because these symbols cannot be encoded in latin1. These error appears only if there are files in request, e.g. content-type header is multipart/form-data. If there are no files in request and content-type header is application/x-www-form-urlencoded then will be no UnicodeEncodeError (cyrillic symbols in data decoded properly).