### PR TITLE
deprecation warnings; make tests runnable standalone

### DIFF
--- a/test/test_app.py
+++ b/test/test_app.py
@@ -13,8 +13,8 @@ class TestApplicationObject(unittest.TestCase):
         """ Attributed can be assigned, but only once. """
         app = Bottle()
         app.test = 5
-        self.assertEquals(5, app.test)
+        self.assertEqual(5, app.test)
         self.assertRaises(AttributeError, setattr, app, 'test', 6) 
         del app.test
         app.test = 6
-        self.assertEquals(6, app.test)
+        self.assertEqual(6, app.test)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -28,8 +28,8 @@ class TestConfDict(unittest.TestCase):
         self.assertEqual('key' in d, 'key' in m)
         self.assertEqual('cay' in d, 'cay' in m)
         self.assertRaises(KeyError, lambda: m['cay'])
-        self.assertEquals(d.setdefault('key', "Val2"), m.setdefault('key', "Val2"))
-        self.assertEquals(d.setdefault('key', "Val3"), m.setdefault('key', "Val3"))
+        self.assertEqual(d.setdefault('key', "Val2"), m.setdefault('key', "Val2"))
+        self.assertEqual(d.setdefault('key', "Val3"), m.setdefault('key', "Val3"))
         self.assertEqual(d.get('key'), m.get('key'))
         with self.assertRaises(KeyError):
             del m['No key']

--- a/test/test_environ.py
+++ b/test/test_environ.py
@@ -8,7 +8,7 @@ import itertools
 
 import bottle
 from bottle import request, tob, touni, tonat, json_dumps, HTTPError, parse_date
-from test import tools
+import tools
 import wsgiref.util
 import base64
 
@@ -489,14 +489,14 @@ class TestResponse(unittest.TestCase):
         from functools import partial
         make_res = partial(BaseResponse, '', 200)
 
-        self.assertEquals('yay', make_res(x_test='yay')['x-test'])
+        self.assertEqual('yay', make_res(x_test='yay')['x-test'])
 
     def test_wsgi_header_values(self):
         def cmp(app, wire):
             rs = BaseResponse()
             rs.set_header('x-test', app)
             result = [v for (h, v) in rs.headerlist if h.lower()=='x-test'][0]
-            self.assertEquals(wire, result)
+            self.assertEqual(wire, result)
 
         if bottle.py3k:
             cmp(1, tonat('1', 'latin1'))

--- a/test/test_html_helper.py
+++ b/test/test_html_helper.py
@@ -8,7 +8,7 @@ class TestHttpUtils(unittest.TestCase):
     # TODO: Move more of the low level http stuff here.
 
     def test_accept_header(self):
-        self.assertEquals(_parse_http_header(
+        self.assertEqual(_parse_http_header(
                 'text/xml, text/whitespace ,'
                 'application/params;param=value; ws = lots ;"quote"="mid\\"quote",'
                 '"more\\"quotes\\"",'

--- a/test/test_jinja2.py
+++ b/test/test_jinja2.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 import unittest
 from bottle import Jinja2Template, jinja2_template, jinja2_view, touni
-from tools import warn
+from tools import warn, chdir
 
-from test.tools import chdir
 
 
 class TestJinja2Template(unittest.TestCase):


### PR DESCRIPTION
fix some deprecation warnings in tests(assertEquals -> assertEqual)
make tests test_environ and test_jinja2 runnable standalone as `python -m unittest test_environ.py`. All another tests have this ability.