### PR TITLE
Travis CI: remove Python 3.3 and add Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,19 @@
+group: travis_latest
 language: python
 sudo: required
 
 python:
   - "2.7.3" # Ubuntu 12.4LTS (precise) and Debian 7 LTS (wheezy)
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
   - "nightly"
+
+jobs:
+  include:
+  - python: "3.7"
+    dist: xenial  # https://github.com/travis-ci/travis-ci/issues/9069
 
 install:
   - travis_retry bash test/travis_setup.sh


### PR DESCRIPTION
* Python 3.3 is went EOL last year  https://devguide.python.org/#branchstatus
* Python 3.7 is shipping  https://github.com/travis-ci/travis-ci/issues/9069