### PR TITLE
Correcting documentation: redirect() raises HTTPResponse and not HTTPError

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -362,7 +362,7 @@ To redirect a client to a different URL, you can send a ``303 See Other`` respon
 You may provide a different HTTP status code as a second parameter.
 
 .. note::
-    Both functions will interrupt your callback code by raising an :exc:`HTTPError` exception.
+    Both functions will interrupt your callback code by raising an :exc:`HTTPResponse` exception.
 
 .. rubric:: Other Exceptions
 


### PR DESCRIPTION
The documentation states, that redirect() raises an HTTPError exception.
But in the code it raises an HTTPResponse
```
def redirect(url, code=None):
    """ Aborts execution and causes a 303 or 302 redirect, depending on
        the HTTP protocol version. """
    if not code:
        code = 303 if request.get('SERVER_PROTOCOL') == "HTTP/1.1" else 302
    res = response.copy(cls=HTTPResponse)
    res.status = code
    res.body = ""
    res.set_header('Location', urljoin(request.url, url))
raise res
```