### PR TITLE
Fix for realoader bug of WSGIServer

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3247,6 +3247,33 @@ class WSGIRefServer(ServerAdapter):
         handler_cls = self.options.get('handler_class', FixedHandler)
         server_cls = self.options.get('server_class', WSGIServer)
 
+        if server_cls is WSGIServer:
+            from wsgiref.simple_server import ServerHandler
+            from wsgiref.handlers import SimpleHandler
+
+            _handle_error = SimpleHandler.handle_error
+
+            def handle_error(self, *args, **kwargs):
+                if sys.exc_info()[0] ==  KeyboardInterrupt:
+                    raise
+                else:
+                    _handle_error(self, *args, **kwargs)
+
+            def close(self):
+                self.result = self.headers = self.status = self.environ = None
+                self.bytes_sent = 0; self.headers_sent = False
+
+            ServerHandler.handle_error = handle_error
+            ServerHandler.close = close
+
+            class _WSGIServer(WSGIServer):
+                def handle_error(self, *args, **kwargs):
+                    if sys.exc_info()[0] ==  KeyboardInterrupt:
+                        raise
+                    else:
+                        return super(_WSGIServer, self).handle_error(*args, **kwargs)
+            server_cls = _WSGIServer
+
         if ':' in self.host:  # Fix wsgiref for IPv6 addresses.
             if getattr(server_cls, 'address_family') == socket.AF_INET:
 


### PR DESCRIPTION
Fix to this issue:
https://github.com/bottlepy/bottle/issues/1094

It's a very ugly solution because I have to do monkey patching but it works. The other option is to run the server in a secondary thread instead of running the server in the main thread and to use a similar approach to Werkzeug and Django. Another possibility is to run the server in another process and simply kill that process when a reload is required. Maybe it's not necessary to close gracefully for most servers. Anyway reloader option is used only for development purposes.