### PR TITLE
Fix X-Forwarded-Host when multiple proxies, see PR#928

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1434,7 +1434,10 @@ class BaseRequest(object):
         env = self.environ
         http = env.get('HTTP_X_FORWARDED_PROTO') \
              or env.get('wsgi.url_scheme', 'http')
-        host = env.get('HTTP_X_FORWARDED_HOST') or env.get('HTTP_HOST')
+        if env.get('HTTP_X_FORWARDED_HOST'):
+            host = env.get('HTTP_X_FORWARDED_HOST').split(",")[0].strip()
+        else:
+            host = env.get('HTTP_HOST')
         if not host:
             # HTTP 1.1 requires a Host-header. This is for HTTP/1.0 clients.
             host = env.get('SERVER_NAME', '127.0.0.1')

--- a/test/test_environ.py
+++ b/test/test_environ.py
@@ -828,6 +828,12 @@ class TestRedirect(unittest.TestCase):
                             HTTP_X_FORWARDED_HOST='example.com',
                             HTTP_HOST='127.0.0.1')
 
+    def test_host_http_multiple_proxies(self):
+        # Trust first proxy when multiple proxies are in front of bottle.
+        self.assertRedirect('./test.html', 'http://example.com/test.html',
+                            HTTP_X_FORWARDED_HOST='example.com, example.net',
+                            HTTP_HOST='127.0.0.1')
+
     def test_specialchars(self):
         ''' The target URL is not quoted automatically. '''
         self.assertRedirect('./te st.html',


### PR DESCRIPTION
See initial bugreport in the PR https://github.com/bottlepy/bottle/pull/928

This should fix the case where bottle is behind multiple reverse-proxy, and each proxy is adding its own X-Forwarded-Host.
When the request arrives at the bottle level, we have multiple values in `X-Forwarded-Host: www.foo.com, xyz.foo.local`. It makes any uses of `request.url`/`bottle functions` not possible. 

E.g. 
With `X-Forwarded-Host: www.foo.com, xyz.foo.local` given:

Before the patch:
`request.url == 'http://www.foo.com, xyz.foo.local/index.html'`

After the patch:
`request.url == 'http://www.foo.com/index.html'`
