### PR TITLE
Fix a problem of crashing when reloading.

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3659,6 +3659,7 @@ def run(app=None,
     if NORUN: return
     if reloader and not os.environ.get('BOTTLE_CHILD'):
         import subprocess
+        import py_compile
         lockfile = None
         try:
             fd, lockfile = tempfile.mkstemp(prefix='bottle.', suffix='.lock')
@@ -3668,6 +3669,18 @@ def run(app=None,
                 environ = os.environ.copy()
                 environ['BOTTLE_CHILD'] = 'true'
                 environ['BOTTLE_LOCKFILE'] = lockfile
+                success = False
+                while not success:
+                    filepath = os.path.join(os.getcwd(), sys.argv[0])
+                    _stderr("Veryfing python script %s\n" % filepath)
+                    try:
+                        py_compile.compile(filepath, doraise=True)
+                        success = True
+                    except py_compile.PyCompileError as e: 
+                        _stderr("Failed to load script because of compile error\n")
+
+                    time.sleep(interval)
+
                 p = subprocess.Popen(args, env=environ)
                 while p.poll() is None:  # Busy wait...
                     os.utime(lockfile, None)  # I am alive!


### PR DESCRIPTION
Hello,

Thank you for nice framework.
I made a small patch to the reloading feature.
Could you take a look at this PR and give me a opinion about this approach.

## The situation to use this feature
This patch allow user to prevent exiting server when reloading SyntaxError containing file.
This patch is slightly related to the problem mentioned in https://github.com/bottlepy/bottle/issues/240, but this patch solve the different problem of running server with `python run_server.py` not `python bottle.py run_server.py`.

## How to test
1. Save and run code above.
```
import bottle

app = bottle.Bottle()

@app.get('test')
def test():
    return 'test'

bottle.run(app=app, port=9100, host='0.0.0.0', reloader=True)
```
2. Make some syntax error to the file while running.

Thank you!