### PR TITLE
Fix Python 3.7 collections.abc DeprecationWarning

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -129,7 +129,7 @@ if py3k:
     from urllib.parse import urlencode, quote as urlquote, unquote as urlunquote
     urlunquote = functools.partial(urlunquote, encoding='latin1')
     from http.cookies import SimpleCookie, Morsel, CookieError
-    from collections import MutableMapping as DictMixin
+    from collections.abc import MutableMapping as DictMixin
     import pickle
     from io import BytesIO
     import configparser


### PR DESCRIPTION
Should fix this

```
/.../bin/bottle.py:87: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import MutableMapping as DictMixin
```