### PR TITLE
#1177 Bug fix of missing regex escaped back slashes

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3430,8 +3430,8 @@ class StplParser(object):
     # 2: Comments (until end of line, but not the newline itself)
     _re_tok += '|(#.*)'
     # 3,4: Open and close grouping tokens
-    _re_tok += '|([\[\{\(])'
-    _re_tok += '|([\]\}\)])'
+    _re_tok += '|([\\[\\{\\(])'
+    _re_tok += '|([\\]\\}\\)])'
     # 5,6: Keywords that start or continue a python block (only start of line)
     _re_tok += '|^([ \\t]*(?:if|for|while|with|try|def|class)\\b)' \
                '|^([ \\t]*(?:elif|else|except|finally)\\b)'


### PR DESCRIPTION
Quick fix to ensure that the regex strings do not cause the bottle app to fail launch.  

Also ties in with the other parts of the constructed regex string parts where the back slashes are escaped.