### PR TITLE
Offer option to add custom headers in static_file

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2835,7 +2835,8 @@ def static_file(filename, root,
                 mimetype=True,
                 download=False,
                 charset='UTF-8',
-                etag=None):
+                etag=None,
+                headers=dict()):
     """ Open a file in a safe way and return an instance of :exc:`HTTPResponse`
         that can be sent back to the client.
 
@@ -2852,6 +2853,8 @@ def static_file(filename, root,
             (default: UTF-8)
         :param etag: Provide a pre-computed ETag header. If set to ``False``,
             ETag handling is disabled. (default: auto-generate ETag header)
+        :param headers: Provide a dictionary with custom headers to add to
+            the response. (default: empty dictionary)
 
         While checking user input is always a good idea, this function provides
         additional protection against malicious ``filename`` parameters from
@@ -2869,7 +2872,6 @@ def static_file(filename, root,
 
     root = os.path.join(os.path.abspath(root), '')
     filename = os.path.abspath(os.path.join(root, filename.strip('/\\')))
-    headers = dict()
 
     if not filename.startswith(root):
         return HTTPError(403, "Access denied.")


### PR DESCRIPTION
static_file does not offer the ability of adding custom headers because the headers dictionary is built inside the function.
changed it so it is a parameter with a default value. Behavior is not changed and the user has the option of supplying custom headers to the response if needed.