### PR TITLE
Add support for non-empty requests with no Content-Length header.

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1300,12 +1300,19 @@ class BaseRequest(object):
         return None
 
     def _iter_body(self, read, bufsize):
-        maxread = max(0, self.content_length)
-        while maxread:
-            part = read(min(maxread, bufsize))
-            if not part: break
-            yield part
-            maxread -= len(part)
+        maxread = self.content_length
+        if maxread == 0:
+            return
+        elif maxread > 0:
+            while maxread > 0:
+                part = read(min(maxread, bufsize))
+                if not part:
+                    raise HTTPError(400, "Unexpected end of stream")
+                maxread -= len(part)
+                yield part
+        else:  # Non Content-Length header
+            # Assume 'wsgi.input_terminated' support or 'Connection: close'
+            yield from iter(lambda: read(bufsize), b'')
 
     @staticmethod
     def _iter_chunked(read, bufsize):


### PR DESCRIPTION
In some situations, a non-empty non-chunked request may lack a
Content-Length header and still be valid:
- HTTP/1.0 clients (default to 'Connection: close')
- HTTP/1.1 clients with 'Connection: close'
- WSGI server transparently decoding 'Transfer-Encoding: chunked'
- WSGI middleware filtering the request body (e.g. gzip)

In all these situations, 'wsgi.input' MUST NOT read across
request boundaries and terminate at the end of the request body,
because WSGI defines no other way to detect the end of the stream.
Most WSGI servers or filtering middleware correctly set 'wsgi.input'
to a limiting wrapper. They MAY signal this via the non-standard
'wsgi.input_terminated' flag, but since not limiting 'wsgi.input'
would be clearly wrong, we can assume support for 'wsgi.input_terminated'
(or 'Connection: close', which has the same effect) even if the flag
is not set.

This patch will cause bottle to read from 'wsgi.input' until it returns
no more bytes if 'Content-Length' is not set. It will also throw an error
if 'Content-Length' is set, but less than the expected number of bytes can
be read.