### PR TITLE
gunicorn: switch to use BaseApplication (fixes #756)

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3459,7 +3459,7 @@ class GunicornServer(ServerAdapter):
     """ Untested. See http://gunicorn.org/configure.html for options. """
 
     def run(self, handler):
-        from gunicorn.app.base import Application
+        from gunicorn.app.base import BaseApplication
 
         if self.host.startswith("unix:"):
             config = {'bind': self.host}
@@ -3468,9 +3468,10 @@ class GunicornServer(ServerAdapter):
 
         config.update(self.options)
 
-        class GunicornApplication(Application):
-            def init(self, parser, opts, args):
-                return config
+        class GunicornApplication(BaseApplication):
+            def load_config(self):
+                for key, value in config.items():
+                    self.cfg.set(key, value)
 
             def load(self):
                 return handler


### PR DESCRIPTION
Gunicorn configuration is now only pulled from what is supplied through Bottle, not (for example) re-parsed from the commandline. Follows Gunicorn's [documented approach for integrated applications](http://docs.gunicorn.org/en/stable/custom.html).

* Before: `./my-bottle-app.py -v` → launches gunicorn, which re-parses `sys.argv`, finds the `-v`, prints the gunicorn version, and quits. Likewise, any command line argument which wasn't valid for gunicorn would cause an `error: unrecognized arguments: --whatever` message.
* After: launches gunicorn

Requires gunicorn >19.0 (Jun 2014)
Fixes #756 