### PR TITLE
Fix typos in documentation.

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -116,7 +116,7 @@ py3k = py.major > 2
 
 
 # Workaround for the "print is a keyword/function" Python 2/3 dilemma
-# and a fallback for mod_wsgi (resticts stdout/err attribute access)
+# and a fallback for mod_wsgi (restricts stdout/err attribute access)
 try:
     _stdout, _stderr = sys.stdout.write, sys.stderr.write
 except IOError:
@@ -606,7 +606,7 @@ class Route(object):
     def get_config(self, key, default=None):
         """ Lookup a config field and return its value, first checking the
             route.config, then route.app.config."""
-        depr(0, 13, "Route.get_config() is deprectated.",
+        depr(0, 13, "Route.get_config() is deprecated.",
                     "The Route.config property already includes values from the"
                     " application config for missing keys. Access it directly.")
         return self.config.get(key, default)
@@ -2755,7 +2755,7 @@ class FileUpload(object):
     content_length = HeaderProperty('Content-Length', reader=int, default=-1)
 
     def get_header(self, name, default=None):
-        """ Return the value of a header within the mulripart part. """
+        """ Return the value of a header within the multipart part. """
         return self.headers.get(name, default)
 
     @cached_property

--- a/bottle.py
+++ b/bottle.py
@@ -2719,7 +2719,7 @@ class ResourceManager(object):
         """ Search for a resource and return an absolute file path, or `None`.
 
             The :attr:`path` list is searched in order. The first match is
-            returend. Symlinks are followed. The result is cached to speed up
+            returned. Symlinks are followed. The result is cached to speed up
             future lookups. """
         if name not in self.cache or DEBUG:
             for path in self.path:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -136,7 +136,7 @@ Release 0.10
   * Introduced a :class:`ConfigDict` that makes accessing configuration a lot easier (attribute access and auto-expanding namespaces).
   * Added support for raw WSGI applications to :meth:`Bottle.mount`.
   * :meth:`Bottle.mount` parameter order changed.
-  * :meth:`Bottle.route` now accpets an import string for the ``callback`` parameter.
+  * :meth:`Bottle.route` now accepts an import string for the ``callback`` parameter.
   * Dropped Gunicorn 0.8 support. Current supported version is 0.13.
   * Added custom options to Gunicorn server.
   * Finally dropped support for type filters. Replace with a custom plugin of needed.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -80,7 +80,7 @@ The best way to get your changes integrated into the main development branch is 
 
 * **Documentation:** Tell us what your patch does. Comment your code. If you introduced a new feature, add to the documentation so others can learn about it.
 * **Test:** Write tests to prove that your code works as expected and does not break anything. If you fixed a bug, write at least one test-case that triggers the bug. Make sure that all tests pass before you submit a patch.
-* **One patch at a time:** Only fix one bug or add one feature at a time. Design your patches so that they can be applyed as a whole. Keep your patches clean, small and focused. 
+* **One patch at a time:** Only fix one bug or add one feature at a time. Design your patches so that they can be applied as a whole. Keep your patches clean, small and focused. 
 * **Sync with upstream:** If the ``upstream/master`` branch changed while you were working on your patch, rebase or pull to make sure that your patch still applies without conflicts.
 
 

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -261,7 +261,7 @@ Using Bottle with Heroku
 ------------------------
 
 Heroku_, a popular cloud application platform now provides support
-for running Python applications on their infastructure. 
+for running Python applications on their infrastructure. 
 
 This recipe is based upon the `Heroku Quickstart 
 <http://devcenter.heroku.com/articles/quickstart>`_, 


### PR DESCRIPTION
Fixes some typos in documentation. The typos are in po files too. Not sure if I need to change them manually or it's done as part of build process.