### PR TITLE
Fixed an issue using lighttpd

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -985,7 +985,7 @@ class Bottle(object):
         return tob(template(ERROR_PAGE_TEMPLATE, e=res, template_settings=dict(name='__ERROR_PAGE_TEMPLATE')))
 
     def _handle(self, environ):
-        path = environ['bottle.raw_path'] = environ['PATH_INFO']
+        path = environ['bottle.raw_path'] = environ.get('PATH_INFO',environ.get('REQUEST_URI','/'))
         if py3k:
             environ['PATH_INFO'] = path.encode('latin1').decode('utf8', 'ignore')
 


### PR DESCRIPTION
Sadly using uwsgi under lighttpd the PATH_INFO environment variable is not set. Technically a lighttpd bug in all likelihood, but I did find this single one line fix is a workaround that sees my bottle app run fine under lightpd and uwsgi.

I'm not really sure this is the right patch, and don't mind in the least learning otherwise. It works on my app which is totally simple in one folder and I simply noticed REQUEST_URI was / and PATH_INFO not set. I have a git feel this doesn't generalise well, but hope this PR prompts a think about a more general path forward when PATH_INFO is missing. It is reverenced in other parts of bottle with defaults anyhow and only this one line crashes for me. So I patched it locally for now.

I will pursue an issue with lighttpd regarding the missing PATH_INFO as well but think it wise that bottle be robust against a missing PATH_INFO all the same.