### PR TITLE
GitHub Action to find syntax errors and undefined names

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,14 @@
+# GitHub Action to automate the identification of common misspellings in text files
+#   and Python syntax errors and undefined names.
+# https://github.com/codespell-project/codespell and https://gitlab.com/pycqa/flake8
+name: lint_python
+on: [push, pull_request]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+      - run: pip install codespell flake8
+      - run: codespell
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -10,5 +10,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
       - run: pip install codespell flake8
-      - run: codespell
+      - run: codespell -L gae,GAE
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics


### PR DESCRIPTION
GitHub Action to automate the identification of common misspellings in text files and Python syntax errors and undefined names.
* https://github.com/codespell-project/codespell
* https://gitlab.com/pycqa/flake8

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.