### PR TITLE
Improved python3.2.x-and-below compat.

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -131,7 +131,10 @@ if py3k:
     from urllib.parse import urlencode, quote as urlquote, unquote as urlunquote
     urlunquote = functools.partial(urlunquote, encoding='latin1')
     from http.cookies import SimpleCookie, Morsel, CookieError
-    from collections.abc import MutableMapping as DictMixin
+    try:
+        from collections.abc import MutableMapping as DictMixin
+    except ImportError:
+        from collections import MutableMapping as DictMixin
     import pickle
     from io import BytesIO
     import configparser


### PR DESCRIPTION
Reused from
https://github.com/shlomif/shlomi-fish-homepage/commit/1b7c9ec6f9d3e7ebce6233219545acd2a1e6c227
due to hostgator.com having 3.2.x.

Note that it is just an improvement - not a guarantee that bottle.py
is actually fully compatible with such old versions. I also will be OK
with these changes being rejected, but just felt it was right to share
them in the spirit of FOSS.

------

I hereby disclaim any implicit or explicit ownership of my changes in this
changeset, and put them under a multiple licence consisting of your choice of
one of more of:

- The CC0 / Public Domain - https://creativecommons.org/choose/zero/ .

- The MIT / Expat license - https://en.wikipedia.org/wiki/MIT_License

- The default licence of your project

- The https://en.wikipedia.org/wiki/GNU_Lesser_General_Public_License - version
2.1 or higher

- The https://en.wikipedia.org/wiki/GNU_General_Public_License - version 2 or
higher

- Any licence in the 2018-Aug-27 popular licenses list of
https://opensource.org/licenses

- The https://en.wikipedia.org/wiki/Apache_License version 2.0 or later

- The https://en.wikipedia.org/wiki/Artistic_License version 2.0 or later

- The https://en.wikipedia.org/wiki/ISC_license

- The https://opensource.org/licenses/BSD-2-Clause

Crediting me will be nice, but not mandatory, and you can change the licence
of the project without needing my permission.