### PR TITLE
Fix broken link to WSGI specification

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -13,7 +13,7 @@
 .. _mod_wsgi: http://code.google.com/p/modwsgi/
 .. _Paste: http://pythonpaste.org/
 .. _Pound: http://www.apsis.ch/pound/
-.. _`WSGI_Specification`: http://www.wsgi.org/
+.. _WSGI_Specification: http://www.wsgi.org/
 .. _issue: http://github.com/bottlepy/bottle/issues
 .. _Python: http://python.org/
 .. _SimpleCookie: http://docs.python.org/library/cookie.html#morsel-objects

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -13,7 +13,7 @@
 .. _mod_wsgi: http://code.google.com/p/modwsgi/
 .. _Paste: http://pythonpaste.org/
 .. _Pound: http://www.apsis.ch/pound/
-.. _`WSGI Specification`: http://www.wsgi.org/
+.. _`WSGI_Specification`: http://www.wsgi.org/
 .. _issue: http://github.com/bottlepy/bottle/issues
 .. _Python: http://python.org/
 .. _SimpleCookie: http://docs.python.org/library/cookie.html#morsel-objects
@@ -675,7 +675,7 @@ You can access the raw body data as a file-like object via :attr:`BaseRequest.bo
 WSGI Environment
 --------------------------------------------------------------------------------
 
-Each :class:`BaseRequest` instance wraps a WSGI environment dictionary. The original is stored in :attr:`BaseRequest.environ`, but the request object itself behaves like a dictionary, too. Most of the interesting data is exposed through special methods or attributes, but if you want to access `WSGI environ variables <WSGI Specification>`_ directly, you can do so::
+Each :class:`BaseRequest` instance wraps a WSGI environment dictionary. The original is stored in :attr:`BaseRequest.environ`, but the request object itself behaves like a dictionary, too. Most of the interesting data is exposed through special methods or attributes, but if you want to access `WSGI environ variables <WSGI_Specification>`_ directly, you can do so::
 
   @route('/my_ip')
   def show_ip():

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -675,7 +675,7 @@ You can access the raw body data as a file-like object via :attr:`BaseRequest.bo
 WSGI Environment
 --------------------------------------------------------------------------------
 
-Each :class:`BaseRequest` instance wraps a WSGI environment dictionary. The original is stored in :attr:`BaseRequest.environ`, but the request object itself behaves like a dictionary, too. Most of the interesting data is exposed through special methods or attributes, but if you want to access `WSGI environ variables <WSGI specification>`_ directly, you can do so::
+Each :class:`BaseRequest` instance wraps a WSGI environment dictionary. The original is stored in :attr:`BaseRequest.environ`, but the request object itself behaves like a dictionary, too. Most of the interesting data is exposed through special methods or attributes, but if you want to access `WSGI environ variables <WSGI Specification>`_ directly, you can do so::
 
   @route('/my_ip')
   def show_ip():


### PR DESCRIPTION
I tried testing this by building it with the bottlepy.org repository, but I wasn't able to get any link to work in the html files generated by that. This link is currently broken on the live page, though, because the capitalization doesn't match.