### PR TITLE
fix: globals().update(include('sample')) overrides local env bound functions

### DIFF
--- a/test/test_stpl.py
+++ b/test/test_stpl.py
@@ -157,6 +157,12 @@ class TestSimpleTemplate(unittest.TestCase):
             t = SimpleTemplate(name='stpl_include', lookup=['./views/'])
             self.assertRenders(t, 'before\nstart var end\nafter\n', var='var')
 
+    def test_include_to_global(self):
+        """ Templates: Updated globals() with include() result"""
+        with chdir(__file__):
+            t = SimpleTemplate(name='stpl_include_to_global', lookup=['./views/'])
+            self.assertRenders(t, 'before\nstart var end\nstart 3 then var end\nafter\n', var='var')
+
     def test_rebase(self):
         """ Templates: %rebase and method passing """
         with chdir(__file__):

--- a/test/views/stpl_include_to_global.tpl
+++ b/test/views/stpl_include_to_global.tpl
@@ -1,0 +1,5 @@
+before
+%globals().update(include('stpl_simple', var=var))
+%the3='3'
+%include('stpl_the3',var=var)
+after

--- a/test/views/stpl_the3.tpl
+++ b/test/views/stpl_the3.tpl
@@ -1,0 +1,1 @@
+start {{the3}} then {{var}} end


### PR DESCRIPTION
I use this to define just functions in templates and then "import" them in the mentioned way.
Then I noticed that a second `%include` behaves differently.
The reason was that the second `%include` is bound to the `env` inside the `include` merged with the current `env` (using `globals().update`).