### PR TITLE
Improve wsgi error handling 013

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1028,6 +1028,7 @@ class Bottle(object):
             stacktrace = format_exc()
             environ['wsgi.errors'].write(stacktrace)
             environ['wsgi.errors'].flush()
+            environ['bottle.exc_info'] = sys.exc_info()
             out = HTTPError(500, "Internal Server Error", E, stacktrace)
             out.apply(response)
 
@@ -1108,6 +1109,7 @@ class Bottle(object):
 
     def wsgi(self, environ, start_response):
         """ The bottle WSGI-interface. """
+        provided_exc_info = False
         try:
             out = self._cast(self._handle(environ))
             # rfc2616 section 4.3
@@ -1115,11 +1117,16 @@ class Bottle(object):
             or environ['REQUEST_METHOD'] == 'HEAD':
                 if hasattr(out, 'close'): out.close()
                 out = []
-            start_response(response._wsgi_status_line(), response.headerlist)
+            exc_info = environ.get('bottle.exc_info')
+            if exc_info is not None:
+                del environ['bottle.exc_info']
+                provided_exc_info = True
+            start_response(response._wsgi_status_line(), response.headerlist, exc_info)
             return out
         except (KeyboardInterrupt, SystemExit, MemoryError):
             raise
         except Exception as E:
+            if provided_exc_info: raise
             if not self.catchall: raise
             err = '<h1>Critical error while processing request: %s</h1>' \
                   % html_escape(environ.get('PATH_INFO', '/'))

--- a/bottle.py
+++ b/bottle.py
@@ -1109,7 +1109,6 @@ class Bottle(object):
 
     def wsgi(self, environ, start_response):
         """ The bottle WSGI-interface. """
-        provided_exc_info = False
         try:
             out = self._cast(self._handle(environ))
             # rfc2616 section 4.3
@@ -1120,13 +1119,11 @@ class Bottle(object):
             exc_info = environ.get('bottle.exc_info')
             if exc_info is not None:
                 del environ['bottle.exc_info']
-                provided_exc_info = True
             start_response(response._wsgi_status_line(), response.headerlist, exc_info)
             return out
         except (KeyboardInterrupt, SystemExit, MemoryError):
             raise
         except Exception as E:
-            if provided_exc_info: raise
             if not self.catchall: raise
             err = '<h1>Critical error while processing request: %s</h1>' \
                   % html_escape(environ.get('PATH_INFO', '/'))

--- a/test/test_exc.py
+++ b/test/test_exc.py
@@ -1,0 +1,30 @@
+import bottle
+from .tools import ServerTestBase
+
+class TestError(Exception):
+    pass
+
+class TestAppException(ServerTestBase):
+
+    def test_no_exc(self):
+        @bottle.route('/')
+        def test(): return 'test'
+        self.assertBody('test', '/')
+
+    def test_memory_error(self):
+        @bottle.route('/')
+        def test(): raise MemoryError
+        self.assertRaises(MemoryError)
+
+    def test_other_error(self):
+        @bottle.route('/')
+        def test(): raise TestError
+        self.assertRaises(TestError)
+
+    def test_noncatched_error(self):
+        @bottle.route('/')
+        def test(): raise TestError
+        bottle.request.environ['exc_info'] = None
+        bottle.catchall = False
+        self.assertStatus(500, '/')
+        self.assertInBody('TestError')


### PR DESCRIPTION
Recommended by pep-3333 to enable middleware to provide exception handling
services, e.g. custom exception logging.

See https://www.python.org/dev/peps/pep-3333/#error-handling

Note that the exc_info is temporarily stored in the environ to pass it up
from _handler() to wsgi(), where start_response() is called. There may be
a better way to do this, e.g. storing it in the response object.

Supersedes https://github.com/bottlepy/bottle/pull/1097, and includes the tests from @BubaVV in https://github.com/bottlepy/bottle/pull/1103