### PR TITLE
Add bottle tools to plugins doc page

### DIFF
--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -74,6 +74,9 @@ Have a look at :ref:`plugins` for general questions about plugins (installation,
 `Bottle-errorsrest <https://github.com/agalera/bottle-errorsrest>`_
 	All errors generated from bottle are returned in json
 
+`Bottle-tools <https://github.com/theSage21/bottle-tools>`_
+	Decorators that auto-supply function arguments using POST/query string data.
+
 
 Plugins listed here are not part of Bottle or the Bottle project, but developed and maintained by third parties.
 


### PR DESCRIPTION
I made something based on bottle that allows us to auto-fill function arguments using request data.

```python
## This function can reside anywhere in your codebase

@fill_args
def some_function(json_key):
    # json_key will automatically be injected into the function call
    # from the POST data supplied in bottle.request
    pass

## You can then call it like this:

some_function()
```

I'm not sure if bottle accepts these kinds of pull requests but I thought I'd give it a shot anyways. :shrug: Thanks for the amazing project.