### PR TITLE
Clean eol python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup
 
 if sys.version_info < (2, 7):
-    raise NotImplementedError("Sorry, you need at least Python 2.7 or Python 3.5+ to use bottle.")
+    raise NotImplementedError("Sorry, you need at least Python 2.7 or Python 3.6+ to use bottle.")
 
 import bottle
 
@@ -33,7 +33,6 @@ setup(name='bottle',
                    'Topic :: Software Development :: Libraries :: Application Frameworks',
                    'Programming Language :: Python :: 2.7',
                    'Programming Language :: Python :: 3',
-                   'Programming Language :: Python :: 3.5',
                    'Programming Language :: Python :: 3.6',
                    'Programming Language :: Python :: 3.7',
                    ],

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,7 @@ setup(name='bottle',
                    'Programming Language :: Python :: 3',
                    'Programming Language :: Python :: 3.6',
                    'Programming Language :: Python :: 3.7',
+                   'Programming Language :: Python :: 3.8',
+                   'Programming Language :: Python :: 3.9',
                    ],
       )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup
 
 if sys.version_info < (2, 7):
-    raise NotImplementedError("Sorry, you need at least Python 2.7 or Python 3.4+ to use bottle.")
+    raise NotImplementedError("Sorry, you need at least Python 2.7 or Python 3.5+ to use bottle.")
 
 import bottle
 
@@ -33,7 +33,6 @@ setup(name='bottle',
                    'Topic :: Software Development :: Libraries :: Application Frameworks',
                    'Programming Language :: Python :: 2.7',
                    'Programming Language :: Python :: 3',
-                   'Programming Language :: Python :: 3.4',
                    'Programming Language :: Python :: 3.5',
                    'Programming Language :: Python :: 3.6',
                    'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,py39,py27-most
+envlist = py27,py36,py37,py38,py39,py27-most
 
 [testenv]
 deps=Mako

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,py27-most
+envlist = py27,py35,py36,py37,py38,py39,py27-most
 
 [testenv]
 deps=Mako


### PR DESCRIPTION
Bottle currently declares support for EOL versions of Python.
Also, some supported Python versions aren't properly published.
