### PR TITLE
Don't mutate headers dict passed into static_file()

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2881,7 +2881,7 @@ def static_file(filename, root,
 
     root = os.path.join(os.path.abspath(root), '')
     filename = os.path.abspath(os.path.join(root, filename.strip('/\\')))
-    headers = headers or {}
+    headers = headers.copy() if headers else {}
 
     if not filename.startswith(root):
         return HTTPError(403, "Access denied.")

--- a/test/test_sendfile.py
+++ b/test/test_sendfile.py
@@ -142,3 +142,13 @@ class TestSendFile(unittest.TestCase):
         self.assertEqual([(10, 100)], r('bytes=10-'))
         self.assertEqual([(5, 11)],  r('bytes=5-10'))
         self.assertEqual([(10, 100), (90, 100), (5, 11)],  r('bytes=10-,-10,5-10'))
+
+    def test_custom_headers(self):
+        """ SendFile: Custom headers """
+        headers = {'X-Custom-Header': 'test-value'}
+        headers_orig = headers.copy()
+        res = static_file(basename, root=root, headers=headers)
+        self.assertTrue('X-Custom-Header' in res.headers)
+        self.assertEqual('test-value', res.headers['X-Custom-Header'])
+        # Check the passed in headers dict isn't modified.
+        self.assertEqual(headers_orig, headers)


### PR DESCRIPTION
Mutating the passed in dict can produce unexpected results if the caller re-uses the dict, e.g. uses the same set of headers for multiple files.