### PR TITLE
Fix build by dropping support for fapws3 server

### DIFF
--- a/.github/workflows/install-deps.sh
+++ b/.github/workflows/install-deps.sh
@@ -5,11 +5,10 @@ set -x
 # Test utilities
 pip install -U pip pytest coverage
 
-# Test dependencies (Server back-ends and template engines)
-sudo apt-get install -y libev-dev
+# Test dependencies (template engines)
 pip install mako jinja2
 
 for name in waitress "cherrypy<9" cheroot paste tornado twisted diesel meinheld\
-            gunicorn eventlet flup fapws3 bjoern gevent aiohttp-wsgi uvloop; do
+            gunicorn eventlet flup bjoern gevent aiohttp-wsgi uvloop; do
     pip install $name || echo "Failed to install $name with $(python -V 2>&1)" 1>&2
 done

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,6 @@
 .. _cheetah: http://www.cheetahtemplate.org/
 .. _jinja2: http://jinja.pocoo.org/
 .. _paste: http://pythonpaste.org/
-.. _fapws3: https://github.com/william-os4y/fapws3
 .. _bjoern: https://github.com/jonashaag/bjoern
 .. _cherrypy: http://www.cherrypy.org/
 .. _WSGI: http://www.wsgi.org/
@@ -35,7 +34,7 @@ Bottle is a fast, simple and lightweight WSGI_ micro web-framework for Python_. 
 * **Routing:** Requests to function-call mapping with support for clean and  dynamic URLs.
 * **Templates:** Fast and pythonic `*built-in template engine* <http://bottlepy.org/docs/dev/tutorial.html#tutorial-templates>`_ and support for mako_, jinja2_ and cheetah_ templates.
 * **Utilities:** Convenient access to form data, file uploads, cookies, headers and other HTTP-related metadata.
-* **Server:** Built-in HTTP development server and support for paste_, fapws3_, bjoern_, `Google App Engine <https://cloud.google.com/appengine/>`_, cherrypy_ or any other WSGI_ capable HTTP server.
+* **Server:** Built-in HTTP development server and support for paste_, bjoern_, `Google App Engine <https://cloud.google.com/appengine/>`_, cherrypy_ or any other WSGI_ capable HTTP server.
 
 Homepage and documentation: http://bottlepy.org
 

--- a/bottle.py
+++ b/bottle.py
@@ -3360,31 +3360,6 @@ class MeinheldServer(ServerAdapter):
         server.run(handler)
 
 
-class FapwsServer(ServerAdapter):
-    """ Extremely fast webserver using libev. See http://www.fapws.org/ """
-
-    def run(self, handler):  # pragma: no cover
-        import fapws._evwsgi as evwsgi
-        from fapws import base, config
-        port = self.port
-        if float(config.SERVER_IDENT[-2:]) > 0.4:
-            # fapws3 silently changed its API in 0.5
-            port = str(port)
-        evwsgi.start(self.host, port)
-        # fapws3 never releases the GIL. Complain upstream. I tried. No luck.
-        if 'BOTTLE_CHILD' in os.environ and not self.quiet:
-            _stderr("WARNING: Auto-reloading does not work with Fapws3.\n")
-            _stderr("         (Fapws3 breaks python thread support)\n")
-        evwsgi.set_base_module(base)
-
-        def app(environ, start_response):
-            environ['wsgi.multiprocess'] = False
-            return handler(environ, start_response)
-
-        evwsgi.wsgi_cb(('', app))
-        evwsgi.run()
-
-
 class TornadoServer(ServerAdapter):
     """ The super hyped asynchronous server by facebook. Untested. """
 
@@ -3576,7 +3551,6 @@ server_names = {
     'cherrypy': CherryPyServer,
     'cheroot': CherootServer,
     'paste': PasteServer,
-    'fapws3': FapwsServer,
     'tornado': TornadoServer,
     'gae': AppEngineServer,
     'twisted': TwistedServer,

--- a/docs/_locale/_pot/deployment.pot
+++ b/docs/_locale/_pot/deployment.pot
@@ -214,14 +214,6 @@ msgid "diesel_"
 msgstr ""
 
 #: ../../deployment.rst:74
-msgid "fapws3"
-msgstr ""
-
-#: ../../deployment.rst:74
-msgid "fapws3_"
-msgstr ""
-
-#: ../../deployment.rst:74
 msgid "Asynchronous (network side only), written in C"
 msgstr ""
 

--- a/docs/_locale/_pot/index.pot
+++ b/docs/_locale/_pot/index.pot
@@ -37,7 +37,7 @@ msgid "**Utilities:** Convenient access to form data, file uploads, cookies, hea
 msgstr ""
 
 #: ../../index.rst:29
-msgid "**Server:** Built-in HTTP development server and support for paste_, fapws3_, bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
+msgid "**Server:** Built-in HTTP development server and support for paste_, bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
 msgstr ""
 
 #: ../../index.rst:32

--- a/docs/_locale/_pot/tutorial_app.pot
+++ b/docs/_locale/_pot/tutorial_app.pot
@@ -473,7 +473,7 @@ msgid "As said above, the standard server is perfectly suitable for development,
 msgstr ""
 
 #: ../../tutorial_app.rst:475
-msgid "But Bottle has already various adapters to multi-threaded servers on board, which perform better on higher load. Bottle supports Cherrypy_, Fapws3_, Flup_ and Paste_."
+msgid "But Bottle has already various adapters to multi-threaded servers on board, which perform better on higher load. Bottle supports Cherrypy_, Flup_ and Paste_."
 msgstr ""
 
 #: ../../tutorial_app.rst:477
@@ -481,7 +481,7 @@ msgid "If you want to run for example Bottle with the Paste server, use the foll
 msgstr ""
 
 #: ../../tutorial_app.rst:483
-msgid "This works exactly the same way with ``FlupServer``, ``CherryPyServer`` and ``FapwsServer``."
+msgid "This works exactly the same way with ``FlupServer`` and ``CherryPyServer``."
 msgstr ""
 
 #: ../../tutorial_app.rst:487

--- a/docs/_locale/de_DE/LC_MESSAGES/deployment.po
+++ b/docs/_locale/de_DE/LC_MESSAGES/deployment.po
@@ -252,14 +252,6 @@ msgid "diesel_"
 msgstr ""
 
 #: ../../deployment.rst:74
-msgid "fapws3"
-msgstr ""
-
-#: ../../deployment.rst:74
-msgid "fapws3_"
-msgstr ""
-
-#: ../../deployment.rst:74
 msgid "Asynchronous (network side only), written in C"
 msgstr ""
 

--- a/docs/_locale/de_DE/LC_MESSAGES/index.po
+++ b/docs/_locale/de_DE/LC_MESSAGES/index.po
@@ -49,7 +49,7 @@ msgstr ""
 #: ../../index.rst:29
 msgid ""
 "**Server:** Built-in HTTP development server and support for paste_, "
-"fapws3_, bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
+"bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
 msgstr ""
 
 #: ../../index.rst:32

--- a/docs/_locale/de_DE/LC_MESSAGES/tutorial_app.po
+++ b/docs/_locale/de_DE/LC_MESSAGES/tutorial_app.po
@@ -760,7 +760,7 @@ msgstr ""
 #: ../../tutorial_app.rst:475
 msgid ""
 "But Bottle has already various adapters to multi-threaded servers on board, "
-"which perform better on higher load. Bottle supports Cherrypy_, Fapws3_, "
+"which perform better on higher load. Bottle supports Cherrypy_, "
 "Flup_ and Paste_."
 msgstr ""
 
@@ -772,8 +772,7 @@ msgstr ""
 
 #: ../../tutorial_app.rst:483
 msgid ""
-"This works exactly the same way with ``FlupServer``, ``CherryPyServer`` and "
-"``FapwsServer``."
+"This works exactly the same way with ``FlupServer`` and ``CherryPyServer``."
 msgstr ""
 
 #: ../../tutorial_app.rst:487

--- a/docs/_locale/pt_BR/LC_MESSAGES/_pot/deployment.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/_pot/deployment.po
@@ -246,14 +246,6 @@ msgid "diesel_"
 msgstr ""
 
 #: ../../deployment.rst:74
-msgid "fapws3"
-msgstr ""
-
-#: ../../deployment.rst:74
-msgid "fapws3_"
-msgstr ""
-
-#: ../../deployment.rst:74
 msgid "Asynchronous (network side only), written in C"
 msgstr ""
 

--- a/docs/_locale/pt_BR/LC_MESSAGES/_pot/index.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/_pot/index.po
@@ -43,7 +43,7 @@ msgstr ""
 #: ../../index.rst:29
 msgid ""
 "**Server:** Built-in HTTP development server and support for paste_, "
-"fapws3_, bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
+"bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
 msgstr ""
 
 #: ../../index.rst:32

--- a/docs/_locale/pt_BR/LC_MESSAGES/_pot/tutorial_app.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/_pot/tutorial_app.po
@@ -793,7 +793,7 @@ msgstr ""
 #: ../../tutorial_app.rst:494
 msgid ""
 "But Bottle has already various adapters to multi-threaded servers on board, "
-"which perform better on higher load. Bottle supports Cherrypy_, Fapws3_, "
+"which perform better on higher load. Bottle supports Cherrypy_, "
 "Flup_ and Paste_."
 msgstr ""
 
@@ -805,8 +805,7 @@ msgstr ""
 
 #: ../../tutorial_app.rst:502
 msgid ""
-"This works exactly the same way with ``FlupServer``, ``CherryPyServer`` and "
-"``FapwsServer``."
+"This works exactly the same way with ``FlupServer`` and ``CherryPyServer``."
 msgstr ""
 
 #: ../../tutorial_app.rst:506

--- a/docs/_locale/pt_BR/LC_MESSAGES/deployment.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/deployment.po
@@ -252,14 +252,6 @@ msgid "diesel_"
 msgstr ""
 
 #: ../../deployment.rst:74
-msgid "fapws3"
-msgstr ""
-
-#: ../../deployment.rst:74
-msgid "fapws3_"
-msgstr ""
-
-#: ../../deployment.rst:74
 msgid "Asynchronous (network side only), written in C"
 msgstr ""
 

--- a/docs/_locale/pt_BR/LC_MESSAGES/index.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/index.po
@@ -53,8 +53,8 @@ msgstr "**Utilitários:** Conveniente acesso a dados de formulários, upload de 
 #: ../../index.rst:29
 msgid ""
 "**Server:** Built-in HTTP development server and support for paste_, "
-"fapws3_, bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
-msgstr "**Servidor:** Servidor HTTP interno para desenvolvimento e suporte para paste_, fapws3_, bjoern_, gae_, cherrypy_ ou qualquer outro WSGI_ capaz de servir HTTP"
+"bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
+msgstr "**Servidor:** Servidor HTTP interno para desenvolvimento e suporte para paste_, bjoern_, gae_, cherrypy_ ou qualquer outro WSGI_ capaz de servir HTTP"
 
 #: ../../index.rst:32
 msgid "Example: \"Hello World\" in a bottle"

--- a/docs/_locale/pt_BR/LC_MESSAGES/tutorial_app.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/tutorial_app.po
@@ -760,7 +760,7 @@ msgstr ""
 #: ../../tutorial_app.rst:475
 msgid ""
 "But Bottle has already various adapters to multi-threaded servers on board, "
-"which perform better on higher load. Bottle supports Cherrypy_, Fapws3_, "
+"which perform better on higher load. Bottle supports Cherrypy_, "
 "Flup_ and Paste_."
 msgstr ""
 
@@ -772,8 +772,7 @@ msgstr ""
 
 #: ../../tutorial_app.rst:483
 msgid ""
-"This works exactly the same way with ``FlupServer``, ``CherryPyServer`` and "
-"``FapwsServer``."
+"This works exactly the same way with ``FlupServer`` and ``CherryPyServer``."
 msgstr ""
 
 #: ../../tutorial_app.rst:487

--- a/docs/_locale/zh_CN/LC_MESSAGES/_pot/deployment.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/_pot/deployment.po
@@ -246,14 +246,6 @@ msgid "diesel_"
 msgstr ""
 
 #: ../../deployment.rst:74
-msgid "fapws3"
-msgstr ""
-
-#: ../../deployment.rst:74
-msgid "fapws3_"
-msgstr ""
-
-#: ../../deployment.rst:74
 msgid "Asynchronous (network side only), written in C"
 msgstr ""
 

--- a/docs/_locale/zh_CN/LC_MESSAGES/_pot/index.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/_pot/index.po
@@ -43,7 +43,7 @@ msgstr ""
 #: ../../index.rst:29
 msgid ""
 "**Server:** Built-in HTTP development server and support for paste_, "
-"fapws3_, bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
+"bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
 msgstr ""
 
 #: ../../index.rst:32

--- a/docs/_locale/zh_CN/LC_MESSAGES/_pot/tutorial_app.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/_pot/tutorial_app.po
@@ -793,7 +793,7 @@ msgstr ""
 #: ../../tutorial_app.rst:494
 msgid ""
 "But Bottle has already various adapters to multi-threaded servers on board, "
-"which perform better on higher load. Bottle supports Cherrypy_, Fapws3_, "
+"which perform better on higher load. Bottle supports Cherrypy_, "
 "Flup_ and Paste_."
 msgstr ""
 
@@ -805,8 +805,7 @@ msgstr ""
 
 #: ../../tutorial_app.rst:502
 msgid ""
-"This works exactly the same way with ``FlupServer``, ``CherryPyServer`` and "
-"``FapwsServer``."
+"This works exactly the same way with ``FlupServer`` and ``CherryPyServer``."
 msgstr ""
 
 #: ../../tutorial_app.rst:506

--- a/docs/_locale/zh_CN/LC_MESSAGES/deployment.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/deployment.po
@@ -252,14 +252,6 @@ msgid "diesel_"
 msgstr ""
 
 #: ../../deployment.rst:74
-msgid "fapws3"
-msgstr ""
-
-#: ../../deployment.rst:74
-msgid "fapws3_"
-msgstr ""
-
-#: ../../deployment.rst:74
 msgid "Asynchronous (network side only), written in C"
 msgstr "异步 (network side only), written in C"
 

--- a/docs/_locale/zh_CN/LC_MESSAGES/index.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/index.po
@@ -49,7 +49,7 @@ msgstr "**基础功能(Utilities):** 方便地访问表单数据，上传文件�
 #: ../../index.rst:29
 msgid ""
 "**Server:** Built-in HTTP development server and support for paste_, "
-"fapws3_, bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
+"bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
 msgstr ""
 
 #: ../../index.rst:32

--- a/docs/_locale/zh_CN/LC_MESSAGES/tutorial_app.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/tutorial_app.po
@@ -760,9 +760,9 @@ msgstr "在大型项目上，Bottle自带的服务器会成为一个性能瓶颈
 #: ../../tutorial_app.rst:475
 msgid ""
 "But Bottle has already various adapters to multi-threaded servers on board, "
-"which perform better on higher load. Bottle supports Cherrypy_, Fapws3_, "
+"which perform better on higher load. Bottle supports Cherrypy_, "
 "Flup_ and Paste_."
-msgstr "Bottle已经可以工作在很多多线程的服务器上面了，例如 Cherrypy_, Fapws3_, Flup_ 和 Paste_ ，所以我们建议在大型项目上使用高性能的服务器。"
+msgstr "Bottle已经可以工作在很多多线程的服务器上面了，例如 Cherrypy_, Flup_ 和 Paste_ ，所以我们建议在大型项目上使用高性能的服务器。"
 
 #: ../../tutorial_app.rst:477
 msgid ""
@@ -772,9 +772,8 @@ msgstr "如果想运行在Paste服务器上面，代码如下(译者注：需要
 
 #: ../../tutorial_app.rst:483
 msgid ""
-"This works exactly the same way with ``FlupServer``, ``CherryPyServer`` and "
-"``FapwsServer``."
-msgstr "其他服务器如 ``FlupServer``, ``CherryPyServer`` 和 ``FapwsServer`` 也类似。"
+"This works exactly the same way with ``FlupServer`` and ``CherryPyServer``."
+msgstr "其他服务器如 ``FlupServer`` 和 ``CherryPyServer`` 也类似。"
 
 #: ../../tutorial_app.rst:487
 msgid "Running Bottle on Apache with mod_wsgi"

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -4,7 +4,6 @@
 .. _cherrypy: http://www.cherrypy.org/
 .. _paste: http://pythonpaste.org/
 .. _gunicorn: http://pypi.python.org/pypi/gunicorn
-.. _fapws3: http://www.fapws.org/
 .. _tornado: http://www.tornadoweb.org/
 .. _twisted: http://twistedmatrix.com/
 .. _diesel: http://dieselweb.org/
@@ -72,7 +71,6 @@ gunicorn  gunicorn_     Pre-forked, partly written in C
 eventlet  eventlet_     Asynchronous framework with WSGI support.
 gevent    gevent_       Asynchronous (greenlets)
 diesel    diesel_       Asynchronous (greenlets)
-fapws3    fapws3_       Asynchronous (network side only), written in C
 tornado   tornado_      Asynchronous, powers some parts of Facebook
 twisted   twisted_      Asynchronous, well tested but... twisted
 meinheld  meinheld_     Asynchronous, partly written in C

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,6 @@
 .. _cheetah: http://www.cheetahtemplate.org/
 .. _jinja2: http://jinja.pocoo.org/
 .. _paste: http://pythonpaste.org/
-.. _fapws3: https://github.com/william-os4y/fapws3
 .. _bjoern: https://github.com/jonashaag/bjoern
 .. _flup: http://trac.saddi.com/flup
 .. _cherrypy: http://www.cherrypy.org/
@@ -26,7 +25,7 @@ Bottle is a fast, simple and lightweight WSGI_ micro web-framework for Python_. 
 * **Routing:** Requests to function-call mapping with support for clean and  dynamic URLs.
 * **Templates:** Fast and pythonic :ref:`built-in template engine <tutorial-templates>` and support for mako_, jinja2_ and cheetah_ templates.
 * **Utilities:** Convenient access to form data, file uploads, cookies, headers and other HTTP-related metadata.
-* **Server:** Built-in HTTP development server and support for paste_, fapws3_, bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server.
+* **Server:** Built-in HTTP development server and support for paste_, bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server.
 
 .. rubric:: Example: "Hello World" in a bottle
 

--- a/docs/tutorial_app.rst
+++ b/docs/tutorial_app.rst
@@ -7,7 +7,6 @@
 .. _`Python DB API`: http://www.python.org/dev/peps/pep-0249/
 .. _`WSGI reference Server`: http://docs.python.org/library/wsgiref.html#module-wsgiref.simple_server
 .. _Cherrypy: http://www.cherrypy.org/
-.. _Fapws3: http://github.com/william-os4y/fapws3
 .. _Flup: https://www.saddi.com/software/flup/
 .. _Paste: http://pythonpaste.org/
 .. _Apache: http://www.apache.org
@@ -486,7 +485,7 @@ The ``port`` and ``host`` parameter can also be applied when Bottle is running w
 
 As said above, the standard server is perfectly suitable for development, personal use or a small group of people only using your application based on Bottle. For larger tasks, the standard server may become a bottleneck, as it is single-threaded, thus it can only serve one request at a time.
 
-But Bottle has already various adapters to multi-threaded servers on board, which perform better on higher load. Bottle supports Cherrypy_, Fapws3_, Flup_ and Paste_.
+But Bottle has already various adapters to multi-threaded servers on board, which perform better on higher load. Bottle supports Cherrypy_, Flup_ and Paste_.
 
 If you want to run for example Bottle with the Paste server, use the following code::
 
@@ -494,7 +493,7 @@ If you want to run for example Bottle with the Paste server, use the following c
     ...
     run(server=PasteServer)
 
-This works exactly the same way with ``FlupServer``, ``CherryPyServer`` and ``FapwsServer``.
+This works exactly the same way with ``FlupServer`` and ``CherryPyServer``.
 
 
 .. rubric:: Running Bottle on Apache with mod_wsgi

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -109,7 +109,6 @@ else:
     blacklist += [
         'bjoern',
         'diesel',
-        'fapws3',
         'flup',
         'gevent',
     ]


### PR DESCRIPTION
Github actions currently hangs indefinitely while trying to install fapws3 on Python 2.7, breaking the build. (It just fails on 3.x due to a print statement in the setup.py.)

fapws3 only works with Python 2, which is no longer supported. The project appears to be unmaintained - the last commit was 3 years ago.

(Note: I spent quite a while trying to work out why installing it no longer works on Github actions, without any luck. This seemed like the next best course of action.)