### PR TITLE
Add tests for #602 bug

### DIFF
--- a/test/test_mount.py
+++ b/test/test_mount.py
@@ -6,12 +6,17 @@ class TestAppMounting(ServerTestBase):
     def setUp(self):
         ServerTestBase.setUp(self)
         self.subapp = bottle.Bottle()
-        @self.subapp.route('')
+
         @self.subapp.route('/')
-        @self.subapp.route('/test/:test')
+        @self.subapp.route('/test/<test>')
         def test(test='foo'):
             return test
 
+    def test_mount_unicode_path_bug602(self):
+        self.app.mount('/mount/', self.subapp)
+        self.assertBody('äöü', '/mount/test/äöü')
+        self.app.route('/route/<param>', callback=lambda param: param)
+        self.assertBody('äöü', '/route/äöü')
 
     def test_mount_order_bug581(self):
         self.app.mount('/test/', self.subapp)


### PR DESCRIPTION
It looks that #602 is gone, but I'm not sure when exactly it was fixed.

I see that there is a suspicious change [here](https://github.com/bottlepy/bottle/commit/d85a6983ceedacd9ab9afbcd027139d8773b67ac):

```python
environ['PATH_INFO'] = path.encode('latin1').decode('utf8', 'ignore')
```

Where original cause of the error was removed and replaced by `'ignore'`.

Also fixed deprecation warnings, where:

```python
@self.subapp.route('')
```

Does exactly same thing as this:

```python
@self.subapp.route('/test/<test>')
```

Where `''` is passed to `route()`, then `makelist()` utility assumes that nothing is passed and falls back to path autogeneration from callback function. Not sure if this is expected behaviour?