### PR TITLE
new server adapter

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3288,6 +3288,20 @@ class WSGIRefServer(ServerAdapter):
             self.srv.server_close()  # Prevent ResourceWarning: unclosed socket
             raise
 
+            
+class ServeLightServer(ServerAdapter):
+    def run(self, app):  # pragma: no cover
+        from sl.server import make_server
+        from sl.server import WSGIRequestHandler, ThreadingWSGIServer
+
+        handler_cls = self.options.get('handler_class', FixedHandler)
+        server_cls = self.options.get('server_class', ThreadingWSGIServer)
+
+        self.srv = make_server(self.host, self.port, app, server_cls,
+                               handler_cls)
+        self.port = self.srv.port  # update port actual port (0 means random)
+        self.srv.serve_forever()
+
 
 class CherryPyServer(ServerAdapter):
     def run(self, handler):  # pragma: no cover


### PR DESCRIPTION
**new server adapter for [@Ksengine/Servelight](https://github.com/Ksengine/Servelight)**
This server is based on wsgiref source code.
but with following updates.
- PEP 3333 for python 2
- python 2 and 3 both supported
- unix sockets supported
- Fix for IPv6 addresses
- SSL supported
- threading server - uses threads to handle requests. This is useful to handle web browsers pre-opening sockets, on which Server would wait indefinitely.
- multiprocessing server -handle each request in a new process.
- Prevent reverse DNS lookups
- Prevent ResourceWarning: unclosed socket on KeyboardInterrupt
- when given 0 as port use random port and update port to actual port

so I added server adapter
I had read -
- https://github.com/bottlepy/bottle/pull/647#issuecomment-60152870
- https://github.com/bottlepy/bottle/pull/865#issuecomment-242795341

according to #1253 Isuue