### PR TITLE
Improve __repr__ of Route

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -613,7 +613,7 @@ class Route(object):
 
     def __repr__(self):
         cb = self.get_undecorated_callback()
-        return '<%s %r %r>' % (self.method, self.rule, cb)
+        return '<%s:%s %s %s>' % (cb.__module__, cb.__name__, self.method, self.rule)
 
 ###############################################################################
 # Application Object ###########################################################


### PR DESCRIPTION
The current improvement really helps when using multiple apps.

When I start such an application I like logging which routes are
available, for example one can do:

```
for r in main_app.routes:
    print(r)
```

Which previously gave this:

```
<GET '<:re:(de|us)?\\/?>' <function index at 0x7f750fda9670>>
<GET '/<:re:(de/|us/)?>hello/<name:path>/<_id:int>/' <function _index_with_param at 0x7f750fda9700>>
<GET '/<:re:(de/|us/)?><:re:foo>/' <function _index at 0x7f750fda9820>>
<GET '/<:re:(de/|us/)?><url:path>/' <function main at 0x7f750fda9940>>
<GET '<:re:(de|us)?\\/?>' <function main at 0x7f750fda9940>>
<GET '/admin/login/' <function Auth.get_login_template at 0x7f751061e670>>
<POST '/admin/login/' <function Auth.post_login_template at 0x7f751061e700>>
<GET '/admin/' <function index at 0x7f750fd21940>>
<GET '/editor/' <function editor at 0x7f750f930ca0>>
<POST '/editor/template/' <function template_ at 0x7f750f930dc0>>
<GET '/editor/preview/<name:path>' <function load_tmp_template at 0x7f750f930ee0>>
<POST '/editor/validate-jinja/' <function convert at 0x7f750f937040>>
<GET '/static/front/<filepath:path>' <function app_factory.<locals>.server_static at 0x7f750f937af0>>
<GET '/static/admin/<filepath:path>' <function app_factory.<locals>.server_static at 0x7f750f937c10>>
<GET '/static/editor/<filepath:path>' <function app_factory.<locals>.server_static at 0x7f750f937d30>>
```

Memory addresses are of very little use (I can only tell which route is
which because I mount them to different prefixes (e.g. editor, admin,
etc.). This also mathes the directory structure on the file system.
However, this is not always the case, some times I mount applications
without prefix.

With the current patch I can immidietly tell where a route is coming
from:

```
apps.front.views:index GET <:re:(de|us)?\/?>
apps.front.views:_index_with_param GET /<:re:(de/|us/)?>hello/<name:path>/<_id:int>/
apps.front.views:_index GET /<:re:(de/|us/)?><:re:foo>/
apps.front.views:main GET /<:re:(de/|us/)?><url:path>/
apps.front.views:main GET <:re:(de|us)?\/?>
tiny.auth:get_login_template GET /admin/login/
tiny.auth:post_login_template POST /admin/login/
apps.admin.views:index GET /admin/
apps.editor.views:editor GET /editor/
apps.editor.views:template_ POST /editor/template/
apps.editor.views:load_tmp_template GET /editor/preview/<name:path>
apps.editor.views:convert POST /editor/validate-jinja/
__main__:server_static GET /static/front/<filepath:path>
__main__:server_static GET /static/admin/<filepath:path>
__main__:server_static GET /static/editor/<filepath:path>
```

I think this little patch might be usefull for others too.