### PR TITLE
fix erroneous expression

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -575,7 +575,7 @@ class Route(object):
                     callback = plugin(callback)
             except RouteReset:  # Try again with changed configuration.
                 return self._make_callback()
-            if not callback is self.callback:
+            if callback is not self.callback:
                 update_wrapper(callback, self.callback)
         return callback
 


### PR DESCRIPTION
from standart module "operator"
```
def is_not(a, b):
    "Same as a is not b."
    return a is not b
```