### PR TITLE
refactor HeaderDict.filter()

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2269,9 +2269,8 @@ class HeaderDict(MultiDict):
         return MultiDict.get(self, _hkey(key), default, index)
 
     def filter(self, names):
-        for name in (_hkey(n) for n in names):
-            if name in self.dict:
-                del self.dict[name]
+        for name in names:
+            self.dict.pop(_hkey(name), None)
 
 
 class WSGIHeaderDict(DictMixin):


### PR DESCRIPTION
By the way, HeaderDict.filter() seems not used in bottle.py
`filter` is a strange name for this method, something like `drop_keys` would be more correct