### PR TITLE
Python 3 only: pyupgrade --py36-plus **/*.py

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
 Bottle is a fast and simple micro-framework for small web applications. It
 offers request dispatching (Routes) with URL parameter support, templates,
@@ -13,7 +12,6 @@ Copyright (c) 2009-2018, Marcel Hellkamp.
 License: MIT (see LICENSE for details)
 """
 
-from __future__ import print_function
 import sys
 
 __author__ = 'Marcel Hellkamp'
@@ -169,7 +167,7 @@ tonat = touni if py3k else tob
 def _stderr(*args):
     try:
         print(*args, file=sys.stderr)
-    except (IOError, AttributeError):
+    except (OSError, AttributeError):
         pass # Some environments do not allow printing (mod_wsgi)
 
 
@@ -203,7 +201,7 @@ def makelist(data):  # This is just too handy
         return []
 
 
-class DictProperty(object):
+class DictProperty:
     """ Property that maps to a key in a local dict-like attribute. """
 
     def __init__(self, attr, key=None, read_only=False):
@@ -229,7 +227,7 @@ class DictProperty(object):
         del getattr(obj, self.attr)[self.key]
 
 
-class cached_property(object):
+class cached_property:
     """ A property that is only computed once per instance and then replaces
         itself with an ordinary attribute. Deleting the attribute resets the
         property. """
@@ -244,7 +242,7 @@ class cached_property(object):
         return value
 
 
-class lazy_attribute(object):
+class lazy_attribute:
     """ A property that caches itself to the class object. """
 
     def __init__(self, func):
@@ -301,7 +299,7 @@ def _re_flatten(p):
                   len(m.group(1)) % 2 else m.group(1) + '(?:', p)
 
 
-class Router(object):
+class Router:
     """ A Router is an ordered collection of route->target pairs. It is used to
         efficiently match WSGI requests against a number of routes and return
         the first target that satisfies the request. The target may be anything,
@@ -387,7 +385,7 @@ class Router(object):
                     key = 'anon%d' % anons
                     anons += 1
                 else:
-                    pattern += '(?P<%s>%s)' % (key, mask)
+                    pattern += f'(?P<{key}>{mask})'
                     keys.append(key)
                 if in_filter: filters.append((key, in_filter))
                 builder.append((key, out_filter or str))
@@ -407,7 +405,7 @@ class Router(object):
             re_pattern = re.compile('^(%s)$' % pattern)
             re_match = re_pattern.match
         except re.error as e:
-            raise RouteSyntaxError("Could not add Route: %s (%s)" % (rule, e))
+            raise RouteSyntaxError(f"Could not add Route: {rule} ({e})")
 
         if filters:
 
@@ -485,7 +483,7 @@ class Router(object):
                         return target, getargs(path) if getargs else {}
 
         # No matching route found. Collect alternative methods for 405 response
-        allowed = set([])
+        allowed = set()
         nocheck = set(methods)
         for method in set(self.static) - nocheck:
             if path in self.static[method]:
@@ -503,7 +501,7 @@ class Router(object):
         raise HTTPError(404, "Not found: " + repr(path))
 
 
-class Route(object):
+class Route:
     """ This class wraps a route callback along with route specific metadata and
         configuration and applies Plugins on demand. It is also responsible for
         turning an URL path rule into a regular expression usable by the Router.
@@ -607,14 +605,14 @@ class Route(object):
 
     def __repr__(self):
         cb = self.get_undecorated_callback()
-        return '<%s %s -> %s:%s>' % (self.method, self.rule, cb.__module__, cb.__name__)
+        return f'<{self.method} {self.rule} -> {cb.__module__}:{cb.__name__}>'
 
 ###############################################################################
 # Application Object ###########################################################
 ###############################################################################
 
 
-class Bottle(object):
+class Bottle:
     """ Each Bottle object represents a single, distinct web application and
         consists of routes, callbacks, plugins, resources and configuration.
         Instances are callable WSGI applications.
@@ -672,7 +670,7 @@ class Bottle(object):
 
     @cached_property
     def _hooks(self):
-        return dict((name, []) for name in self.__hook_names)
+        return {name: [] for name in self.__hook_names}
 
     def add_hook(self, name, func):
         """ Attach a callback to a hook. Three hooks are currently implemented:
@@ -1154,7 +1152,7 @@ class Bottle(object):
 ###############################################################################
 
 
-class BaseRequest(object):
+class BaseRequest:
     """ A wrapper for WSGI environment dictionaries that adds a lot of
         convenient access methods and properties. Most of them are read-only.
 
@@ -1581,7 +1579,7 @@ class BaseRequest(object):
             self.environ.pop('bottle.request.' + key, None)
 
     def __repr__(self):
-        return '<%s: %s %s>' % (self.__class__.__name__, self.method, self.url)
+        return f'<{self.__class__.__name__}: {self.method} {self.url}>'
 
     def __getattr__(self, name):
         """ Search in self.environ for additional user defined attributes. """
@@ -1618,7 +1616,7 @@ def _hval(value):
     return value
 
 
-class HeaderProperty(object):
+class HeaderProperty:
     def __init__(self, name, reader=None, writer=None, default=''):
         self.name, self.default = name, default
         self.reader, self.writer = reader, writer
@@ -1636,7 +1634,7 @@ class HeaderProperty(object):
         del obj[self.name]
 
 
-class BaseResponse(object):
+class BaseResponse:
     """ Storage class for a response body as well as headers and cookies.
 
         This class does support dict-like case-insensitive item-access to
@@ -1684,7 +1682,7 @@ class BaseResponse(object):
         assert issubclass(cls, BaseResponse)
         copy = cls()
         copy.status = self.status
-        copy._headers = dict((k, v[:]) for (k, v) in self._headers.items())
+        copy._headers = {k: v[:] for (k, v) in self._headers.items()}
         if self._cookies:
             cookies = copy._cookies = SimpleCookie()
             for k,v in self._cookies.items():
@@ -1904,7 +1902,7 @@ class BaseResponse(object):
     def __repr__(self):
         out = ''
         for name, value in self.headerlist:
-            out += '%s: %s\n' % (name.title(), value.strip())
+            out += f'{name.title()}: {value.strip()}\n'
         return out
 
 
@@ -1956,7 +1954,7 @@ Response = BaseResponse
 
 class HTTPResponse(Response, BottleException):
     def __init__(self, body='', status=None, headers=None, **more_headers):
-        super(HTTPResponse, self).__init__(body, status, headers, **more_headers)
+        super().__init__(body, status, headers, **more_headers)
 
     def apply(self, other):
         other._status_code = self._status_code
@@ -1976,7 +1974,7 @@ class HTTPError(HTTPResponse):
                  traceback=None, **more_headers):
         self.exception = exception
         self.traceback = traceback
-        super(HTTPError, self).__init__(body, status, **more_headers)
+        super().__init__(body, status, **more_headers)
 
 ###############################################################################
 # Plugins ######################################################################
@@ -1987,7 +1985,7 @@ class PluginError(BottleException):
     pass
 
 
-class JSONPlugin(object):
+class JSONPlugin:
     name = 'json'
     api = 2
 
@@ -2030,7 +2028,7 @@ class JSONPlugin(object):
         return wrapper
 
 
-class TemplatePlugin(object):
+class TemplatePlugin:
     """ This plugin applies the :func:`view` decorator to all routes with a
         `template` config parameter. If the parameter is a tuple, the second
         element must be a dict with additional options (e.g. `template_engine`)
@@ -2052,7 +2050,7 @@ class TemplatePlugin(object):
 
 
 #: Not a plugin, but part of the plugin API. TODO: Find a better place.
-class _ImportRedirect(object):
+class _ImportRedirect:
     def __init__(self, name, impmask):
         """ Create a virtual package that redirects imports (see PEP 302). """
         self.name = name
@@ -2094,7 +2092,7 @@ class MultiDict(DictMixin):
     """
 
     def __init__(self, *a, **k):
-        self.dict = dict((k, [v]) for (k, v) in dict(*a, **k).items())
+        self.dict = {k: [v] for (k, v) in dict(*a, **k).items()}
 
     def __len__(self):
         return len(self.dict)
@@ -2233,7 +2231,7 @@ class FormsDict(MultiDict):
     def __getattr__(self, name, default=unicode()):
         # Without this guard, pickle generates a cryptic TypeError:
         if name.startswith('__') and name.endswith('__'):
-            return super(FormsDict, self).__getattr__(name)
+            return super().__getattr__(name)
         return self.getunicode(name, default=default)
 
 class HeaderDict(MultiDict):
@@ -2621,7 +2619,7 @@ class AppStack(list):
             return self.push()
 
 
-class WSGIFileWrapper(object):
+class WSGIFileWrapper:
     def __init__(self, fp, buffer_size=1024 * 64):
         self.fp, self.buffer_size = fp, buffer_size
         for attr in 'fileno', 'close', 'read', 'readlines', 'tell', 'seek':
@@ -2635,7 +2633,7 @@ class WSGIFileWrapper(object):
             part = read(buff)
 
 
-class _closeiter(object):
+class _closeiter:
     """ This only exists to be able to attach a .close method to iterators that
         do not support attribute assignment (most of itertools). """
 
@@ -2651,7 +2649,7 @@ class _closeiter(object):
             func()
 
 
-class ResourceManager(object):
+class ResourceManager:
     """ This class manages a list of search paths and helps to find and open
         application-bound resources (files).
 
@@ -2733,11 +2731,11 @@ class ResourceManager(object):
     def open(self, name, mode='r', *args, **kwargs):
         """ Find a resource and return a file object, or raise IOError. """
         fname = self.lookup(name)
-        if not fname: raise IOError("Resource %r not found." % name)
+        if not fname: raise OSError("Resource %r not found." % name)
         return self.opener(fname, mode=mode, *args, **kwargs)
 
 
-class FileUpload(object):
+class FileUpload:
     def __init__(self, fileobj, name, filename, headers=None):
         """ Wrapper for file uploads. """
         #: Open file(-like) object (BytesIO buffer or temporary file)
@@ -2797,7 +2795,7 @@ class FileUpload(object):
             if os.path.isdir(destination):
                 destination = os.path.join(destination, self.filename)
             if not overwrite and os.path.exists(destination):
-                raise IOError('File exists.')
+                raise OSError('File exists.')
             with open(destination, 'wb') as fp:
                 self._copy_file(fp, chunk_size)
         else:
@@ -3217,7 +3215,7 @@ url       = make_default_app_wrapper('get_url')
 # - https://github.com/bottlepy/bottle/pull/647#issuecomment-60152870
 # - https://github.com/bottlepy/bottle/pull/865#issuecomment-242795341
 
-class ServerAdapter(object):
+class ServerAdapter:
     quiet = False
 
     def __init__(self, host='127.0.0.1', port=8080, **options):
@@ -3229,9 +3227,9 @@ class ServerAdapter(object):
         pass
 
     def __repr__(self):
-        args = ', '.join('%s=%s' % (k, repr(v))
+        args = ', '.join('{}={}'.format(k, repr(v))
                           for k, v in self.options.items())
-        return "%s(%s)" % (self.__class__.__name__, args)
+        return f"{self.__class__.__name__}({args})"
 
 
 class CGIServer(ServerAdapter):
@@ -3613,7 +3611,7 @@ def load(target, **namespace):
     if target.isalnum(): return getattr(sys.modules[module], target)
     package_name = module.split('.')[0]
     namespace[package_name] = sys.modules[package_name]
-    return eval('%s.%s' % (module, target), namespace)
+    return eval(f'{module}.{target}', namespace)
 
 
 def load_app(target):
@@ -3793,7 +3791,7 @@ class TemplateError(BottleException):
     pass
 
 
-class BaseTemplate(object):
+class BaseTemplate:
     """ Base class and minimal API for template adapters """
     extensions = ['tpl', 'html', 'thtml', 'stpl']
     settings = {}  #used in prepare()
@@ -3846,8 +3844,8 @@ class BaseTemplate(object):
             if not fname.startswith(spath): continue
             if os.path.isfile(fname): return fname
             for ext in cls.extensions:
-                if os.path.isfile('%s.%s' % (fname, ext)):
-                    return '%s.%s' % (fname, ext)
+                if os.path.isfile(f'{fname}.{ext}'):
+                    return f'{fname}.{ext}'
 
     @classmethod
     def global_config(cls, key, *args):
@@ -4027,7 +4025,7 @@ class StplSyntaxError(TemplateError):
     pass
 
 
-class StplParser(object):
+class StplParser:
     """ Parser for stpl templates. """
     _re_cache = {}  #: Cache for compiled re patterns
 
@@ -4301,8 +4299,8 @@ HTTP_CODES[429] = "Too Many Requests"
 HTTP_CODES[431] = "Request Header Fields Too Large"
 HTTP_CODES[451] = "Unavailable For Legal Reasons" # RFC 7725
 HTTP_CODES[511] = "Network Authentication Required"
-_HTTP_STATUS_LINES = dict((k, '%d %s' % (k, v))
-                          for (k, v) in HTTP_CODES.items())
+_HTTP_STATUS_LINES = {k: '%d %s' % (k, v)
+                          for (k, v) in HTTP_CODES.items()}
 
 #: The default template used for error pages. Override with @error()
 ERROR_PAGE_TEMPLATE = """
@@ -4400,10 +4398,10 @@ def _main(argv):  # pragma: no coverage
                 config.load_config(cfile)
         except configparser.Error as parse_error:
             _cli_error(parse_error)
-        except IOError:
+        except OSError:
             _cli_error("Unable to read config file %r" % cfile)
         except (UnicodeError, TypeError, ValueError) as error:
-            _cli_error("Unable to parse config file %r: %s" % (cfile, error))
+            _cli_error(f"Unable to parse config file {cfile!r}: {error}")
 
     for cval in args.param or []:
         if '=' in cval:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import sys
 import os
 import time
@@ -11,8 +10,8 @@ import bottle
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx',
               'sphinx.ext.viewcode']
 master_doc = 'index'
-project = u'Bottle'
-copyright = u'2009-%s, %s' % (time.strftime('%Y'), bottle.__author__)
+project = 'Bottle'
+copyright = '2009-{}, {}'.format(time.strftime('%Y'), bottle.__author__)
 version = ".".join(bottle.__version__.split(".")[:2])
 release = bottle.__version__
 add_function_parentheses = True

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 from .tools import chdir
 import unittest
 import sys, os

--- a/test/servertest.py
+++ b/test/servertest.py
@@ -27,7 +27,7 @@ def main():
         route('/test', callback=lambda: 'OK')
         run(port=port, server=server, quiet=True)
 
-    except socket.error:
+    except OSError:
         sys.exit(3)
     except ImportError:
         sys.exit(128)

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """ Tests for the functionality of the application object.
 
     TODO: Move other tests here.

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import bottle
 from .tools import ServerTestBase
 

--- a/test/test_contextlocals.py
+++ b/test/test_contextlocals.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 '''
 Some objects are context-local, meaning that they have different values depending on the context they are accessed from. A context is currently defined as a thread.
 '''

--- a/test/test_environ.py
+++ b/test/test_environ.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ''' Tests for the BaseRequest and BaseResponse objects and their subclasses. '''
 
 import unittest
@@ -418,7 +417,7 @@ class TestRequest(unittest.TestCase):
 
     def test_auth(self):
         user, pwd = 'marc', 'secret'
-        basic = touni(base64.b64encode(tob('%s:%s' % (user, pwd))))
+        basic = touni(base64.b64encode(tob(f'{user}:{pwd}')))
         r = BaseRequest({})
         self.assertEqual(r.auth, None)
         r.environ['HTTP_AUTHORIZATION'] = 'basic %s' % basic
@@ -503,7 +502,7 @@ class TestResponse(unittest.TestCase):
 
         if bottle.py3k:
             cmp(1, tonat('1', 'latin1'))
-            cmp('öäü', 'öäü'.encode('utf8').decode('latin1'))
+            cmp('öäü', 'öäü'.encode().decode('latin1'))
             # Dropped byte header support in Python 3:
             #cmp(tob('äöü'), 'äöü'.encode('utf8').decode('latin1'))
         else:

--- a/test/test_fileupload.py
+++ b/test/test_fileupload.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ''' Tests for the FileUpload wrapper. '''
 
 import unittest

--- a/test/test_formsdict.py
+++ b/test/test_formsdict.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # '瓶' means "Bottle"
 
 import unittest

--- a/test/test_importhook.py
+++ b/test/test_importhook.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 import sys, os
 import imp

--- a/test/test_jinja2.py
+++ b/test/test_jinja2.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 from bottle import Jinja2Template, jinja2_template, jinja2_view, touni
 from .tools import warn, chdir

--- a/test/test_mako.py
+++ b/test/test_mako.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import unittest
 from .tools import warn, chdir
 from bottle import MakoTemplate, mako_template, mako_view, touni

--- a/test/test_mount.py
+++ b/test/test_mount.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import bottle
 from .tools import ServerTestBase
 from bottle import response

--- a/test/test_oorouting.py
+++ b/test/test_oorouting.py
@@ -4,17 +4,14 @@ Tests & demonstrates various OO approaches to routes
 import unittest
 import sys
 
-if sys.version_info >= (3, 0, 0):
-    from io import BytesIO
-else:
-    from StringIO import StringIO as BytesIO
+from io import BytesIO
 
 __author__ = 'atc'
 
 from bottle import Bottle, request, tob, BaseRequest
 
 
-class TestRouter(object):
+class TestRouter:
     """
     A test class for wrapping routes to test certain OO scenarios
     """

--- a/test/test_outputfilter.py
+++ b/test/test_outputfilter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 '''Everything returned by Bottle()._cast() MUST be WSGI compatiple.'''
 
 import unittest
@@ -165,7 +164,7 @@ class TestOutputFilter(ServerTestBase):
         self.assertInBody('Unsupported response type')
 
     def test_iterator_with_close(self):
-        class MyIter(object):
+        class MyIter:
             def __init__(self, data):
                 self.data = data
                 self.closed = False

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -1,11 +1,10 @@
-# -*- coding: utf-8 -*-
 import unittest
 from . import tools
 
 from bottle import HTTPResponse, HTTPError, json_dumps
 
 
-class MyPlugin(object):
+class MyPlugin:
     def __init__(self):
         self.app = None
         self.add_args = {}
@@ -167,10 +166,10 @@ class TestPluginManagement(tools.ServerTestBase):
 class TestPluginAPI(tools.ServerTestBase):
 
     def setUp(self):
-        super(TestPluginAPI, self).setUp()
+        super().setUp()
         @self.app.route('/', test='plugin.cfg')
         def test(**args):
-            return ', '.join('%s:%s' % (k,v) for k,v in args.items())
+            return ', '.join(f'{k}:{v}' for k,v in args.items())
 
     def test_callable(self):
         def plugin(func):
@@ -182,7 +181,7 @@ class TestPluginAPI(tools.ServerTestBase):
 
 
     def test_apply(self):
-        class Plugin(object):
+        class Plugin:
             def apply(self, func, route):
                 def wrapper(*a, **ka):
                     return func(test=route.config['test'], *a, **ka) + '; tail'
@@ -194,7 +193,7 @@ class TestPluginAPI(tools.ServerTestBase):
         self.assertBody('test:plugin.cfg; tail', '/')
 
     def test_instance_method_wrapper(self):
-        class Plugin(object):
+        class Plugin:
             api=2
             def apply(self, callback, route):
                 return self.b
@@ -203,14 +202,14 @@ class TestPluginAPI(tools.ServerTestBase):
         self.assertBody('Hello', '/')
 
     def test_setup(self):
-        class Plugin(object):
+        class Plugin:
             def __call__(self, func): return func
             def setup(self, app): self.app = app
         plugin = self.app.install(Plugin())
         self.assertEqual(getattr(plugin, 'app', None), self.app)
 
     def test_close(self):
-        class Plugin(object):
+        class Plugin:
             def __call__(self, func): return func
             def close(self): self.closed = True
         plugin = self.app.install(Plugin())

--- a/test/test_route.py
+++ b/test/test_route.py
@@ -25,7 +25,7 @@ class TestRoute(unittest.TestCase):
             return w
         route = bottle.Route(bottle.Bottle(), None, None, d(x))
         self.assertEqual(route.get_undecorated_callback(), x)
-        self.assertEqual(set(route.get_callback_args()), set(['a', 'b']))
+        self.assertEqual(set(route.get_callback_args()), {'a', 'b'})
 
         def d2(foo):
             def d(f):
@@ -36,7 +36,7 @@ class TestRoute(unittest.TestCase):
 
         route = bottle.Route(bottle.Bottle(), None, None, d2('foo')(x))
         self.assertEqual(route.get_undecorated_callback(), x)
-        self.assertEqual(set(route.get_callback_args()), set(['a', 'b']))
+        self.assertEqual(set(route.get_callback_args()), {'a', 'b'})
 
     def test_callback_inspection_multiple_args(self):
         # decorator with argument, modifying kwargs
@@ -57,11 +57,11 @@ class TestRoute(unittest.TestCase):
         route = bottle.Route(bottle.Bottle(), None, None, x)
 
         # triggers the "TypeError: 'foo' is not a Python function"
-        self.assertEqual(set(route.get_callback_args()), set(['a', 'b']))
+        self.assertEqual(set(route.get_callback_args()), {'a', 'b'})
 
     if bottle.py3k:
         def test_callback_inspection_newsig(self):
             env = {}
             eval(compile('def foo(a, *, b=5): pass', '<foo>', 'exec'), env, env)
             route = bottle.Route(bottle.Bottle(), None, None, env['foo'])
-            self.assertEqual(set(route.get_callback_args()), set(['a', 'b']))
+            self.assertEqual(set(route.get_callback_args()), {'a', 'b'})

--- a/test/test_router.py
+++ b/test/test_router.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import unittest
 import bottle
 

--- a/test/test_securecookies.py
+++ b/test/test_securecookies.py
@@ -1,4 +1,3 @@
-#coding: utf-8
 import unittest
 
 import bottle
@@ -22,7 +21,7 @@ class TestSignedCookies(unittest.TestCase):
                 yield key.lower().strip(), value.strip()
 
     def set_pairs(self, pairs):
-        header = ','.join(['%s=%s' % (k, v) for k, v in pairs])
+        header = ','.join([f'{k}={v}' for k, v in pairs])
         bottle.request.bind({'HTTP_COOKIE': header})
 
     def testValid(self):
@@ -42,5 +41,5 @@ class TestSignedCookies(unittest.TestCase):
 
 class TestSignedCookiesWithPickle(TestSignedCookies):
     def setUp(self):
-        super(TestSignedCookiesWithPickle, self).setUp()
+        super().setUp()
         self.data = dict(a=5, b=touni('υηι¢σ∂є'), c=[1,2,3,4,tob('bytestring')])

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 import time
 import sys
@@ -23,7 +22,7 @@ def ping(server, port):
     try:
         s.connect((server, port))
         return True
-    except socket.error:
+    except OSError:
         return False
     finally:
         s.close()

--- a/test/test_stpl.py
+++ b/test/test_stpl.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import with_statement
 import unittest
 from bottle import SimpleTemplate, TemplateError, view, template, touni, tob, html_quote
 import re, os

--- a/test/test_wsgi.py
+++ b/test/test_wsgi.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import with_statement
 import bottle
 from .tools import ServerTestBase, chdir
 from bottle import tob, touni, HTTPResponse

--- a/test/tools.py
+++ b/test/tools.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import with_statement
 import os
 
 import bottle
@@ -24,7 +22,7 @@ def tobs(data):
     return BytesIO(tob(data))
 
 
-class chdir(object):
+class chdir:
     def __init__(self, dir):
         if os.path.isfile(dir):
             dir = os.path.dirname(dir)
@@ -38,7 +36,7 @@ class chdir(object):
         os.chdir(self.old)
 
 
-class assertWarn(object):
+class assertWarn:
     def __init__(self, text):
         self.searchtext = text
 
@@ -54,7 +52,7 @@ class assertWarn(object):
         self.warnings = []
 
     def depr(self, msg, strict=False):
-        assert self.searchtext in msg, "Could not find phrase %r in warning message %r" % (self.searchtext, msg)
+        assert self.searchtext in msg, f"Could not find phrase {self.searchtext!r} in warning message {msg!r}"
         self.warnings.append(msg)
 
     def __exit__(self, exc_type, exc_val, tb):
@@ -144,7 +142,7 @@ class ServerTestBase(unittest.TestCase):
     def assertInBody(self, body, route='/', **kargs):
         result = self.urlopen(route, **kargs)['body']
         if tob(body) not in result:
-            self.fail('The search pattern "%s" is not included in body:\n%s' % (body, result))
+            self.fail(f'The search pattern "{body}" is not included in body:\n{result}')
 
     def assertHeader(self, name, value, route='/', **kargs):
         self.assertEqual(value, self.urlopen(route, **kargs)['header'].get(name))
@@ -156,7 +154,7 @@ class ServerTestBase(unittest.TestCase):
         bottle.request.environ['wsgi.errors'].errors.seek(0)
         err = bottle.request.environ['wsgi.errors'].errors.read()
         if search not in err:
-            self.fail('The search pattern "%s" is not included in wsgi.error: %s' % (search, err))
+            self.fail(f'The search pattern "{search}" is not included in wsgi.error: {err}')
 
 def multipart_environ(fields, files):
     boundary = str(uuid.uuid1())


### PR DESCRIPTION
As discussed in #1193, this PR was created by running `pyupgrade --py36-plus **/*.py` to modernize Python syntax for Python 3 only usage.  https://github.com/asottile/pyupgrade  @defnull @SergBobrovsky 