### PR TITLE
refactot Route.all_plugins()

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -550,14 +550,14 @@ class Route(object):
 
     def all_plugins(self):
         """ Yield all Plugins affecting this route. """
-        unique = set()
-        for p in reversed(self.app.plugins + self.plugins):
-            if True in self.skiplist: break
-            name = getattr(p, 'name', False)
-            if name and (name in self.skiplist or name in unique): continue
-            if p in self.skiplist or type(p) in self.skiplist: continue
-            if name: unique.add(name)
-            yield p
+        if True in self.skiplist: return
+        skips = set(self.skiplist)
+        for plugins in self.plugins, self.app.plugins:
+            for p in reversed(plugins):
+                if p not in skips and type(p) not in skips:
+                    name = getattr(p, 'name', False)
+                    if name and name not in skips: skips.add(name)
+                    yield p
 
     def _make_callback(self):
         callback = self.callback

--- a/bottle.py
+++ b/bottle.py
@@ -552,11 +552,11 @@ class Route(object):
         """ Yield all Plugins affecting this route. """
         if True in self.skiplist: return
         skips = set(self.skiplist)
-        for plugins in self.plugins, self.app.plugins:
-            for p in reversed(plugins):
-                if p not in skips and type(p) not in skips:
-                    name = getattr(p, 'name', False)
-                    if name and name not in skips: skips.add(name)
+        for p in [*self.plugins[::-1], *self.app.plugins[::-1]]:
+            if p not in skips and type(p) not in skips:
+                name = getattr(p, 'name', False)
+                if not name or name and name not in skips:
+                    skips.add(name)
                     yield p
 
     def _make_callback(self):


### PR DESCRIPTION
My code accurately reproduces original functional, but is it correct?
In original code `unique` collects plugin names to avoid repeats. If plugin has no name, this check not. So, noname plugin can repeats. Is it right logic?