### PR TITLE
remove some redundant from FileCheckerThread.run()

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3760,7 +3760,7 @@ class FileCheckerThread(threading.Thread):
         files = dict()
 
         for module in list(sys.modules.values()):
-            path = getattr(module, '__file__', '') or ''
+            path = getattr(module, '__file__', '')
             if path[-4:] in ('.pyo', '.pyc'): path = path[:-1]
             if path and exists(path): files[path] = mtime(path)
 


### PR DESCRIPTION
third arg of `getattr` is default value