### PR TITLE
Add a max_size parameter to save and _copy_file

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2776,15 +2776,20 @@ class FileUpload(object):
         fname = re.sub(r'[-\s]+', '-', fname).strip('.-')
         return fname[:255] or 'empty'
 
-    def _copy_file(self, fp, chunk_size=2 ** 16):
+    def _copy_file(self, fp, chunk_size=2 ** 16, max_size=None):
         read, write, offset = self.file.read, fp.write, self.file.tell()
         while 1:
             buf = read(chunk_size)
             if not buf: break
+            if max_size is not None:
+                max_size -= len(buf) # Last chunk may be smaller than chunk_size
+                if max_size < 0:
+                    raise IOError('File size exceeds maximum size.')
             write(buf)
         self.file.seek(offset)
 
-    def save(self, destination, overwrite=False, chunk_size=2 ** 16):
+    def save(self, destination, overwrite=False, chunk_size=2 ** 16,
+             max_size=None):
         """ Save file to disk or copy its content to an open file(-like) object.
             If *destination* is a directory, :attr:`filename` is added to the
             path. Existing files are not overwritten by default (IOError).
@@ -2792,6 +2797,8 @@ class FileUpload(object):
             :param destination: File path, directory or file(-like) object.
             :param overwrite: If True, replace existing files. (default: False)
             :param chunk_size: Bytes to read at a time. (default: 64kb)
+            :param max_size: If not None: Maximum number of bytes to write.
+                If exceeded by file size, raise IOError. (default: None)
         """
         if isinstance(destination, basestring):  # Except file-likes here
             if os.path.isdir(destination):
@@ -2799,9 +2806,9 @@ class FileUpload(object):
             if not overwrite and os.path.exists(destination):
                 raise IOError('File exists.')
             with open(destination, 'wb') as fp:
-                self._copy_file(fp, chunk_size)
+                self._copy_file(fp, chunk_size, max_size)
         else:
-            self._copy_file(destination, chunk_size)
+            self._copy_file(destination, chunk_size, max_size)
 
 ###############################################################################
 # Application Helper ###########################################################


### PR DESCRIPTION
This is a proposal inspired by a requirement I had myself and by the following comment on [Stack Overflow](https://stackoverflow.com/questions/22839474/python-bottle-how-to-upload-media-files-without-dosing-the-server#22847275): “Bottle stores file uploads in request.files as FileUpload instances, along with some metadata about the upload. FileUpload has a very handy save method that perform the "file slurping" for you. It does not check the maximum file upload though, but IMHO it's better to have nginx in front to perform this kind of limitation check.”

If you don’t use nginx or so and want to have an upper limit for the file size, it would be nice if the save method had an additional parameter max_size to set a maximum size beyond which the writing is stopped.

The changes in this branch hopefully enable that and I wanna propose to merge them.