### PR TITLE
Redundant system separation in search method

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3841,7 +3841,7 @@ class BaseTemplate(object):
                        "Refer to templates with names or paths relative to the lookup path.")
 
         for spath in lookup:
-            spath = os.path.abspath(spath) + os.sep
+            spath = os.path.abspath(spath)
             fname = os.path.abspath(os.path.join(spath, name))
             if not fname.startswith(spath): continue
             if os.path.isfile(fname): return fname


### PR DESCRIPTION
The os.path.abspath() already output with the separation in the
end of the string, therefore the os.sep() is redundant and can output
missing file when search for template file.