### PR TITLE
Replace cherrypy with cheroot

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@
 .. _paste: http://pythonpaste.org/
 .. _fapws3: https://github.com/william-os4y/fapws3
 .. _bjoern: https://github.com/jonashaag/bjoern
-.. _cherrypy: http://www.cherrypy.org/
+.. _cheroot: https://cheroot.rtfd.io/
 .. _WSGI: http://www.wsgi.org/
 .. _Python: http://python.org/
 
@@ -35,7 +35,7 @@ Bottle is a fast, simple and lightweight WSGI_ micro web-framework for Python_. 
 * **Routing:** Requests to function-call mapping with support for clean and  dynamic URLs.
 * **Templates:** Fast and pythonic `*built-in template engine* <http://bottlepy.org/docs/dev/tutorial.html#tutorial-templates>`_ and support for mako_, jinja2_ and cheetah_ templates.
 * **Utilities:** Convenient access to form data, file uploads, cookies, headers and other HTTP-related metadata.
-* **Server:** Built-in HTTP development server and support for paste_, fapws3_, bjoern_, `Google App Engine <https://cloud.google.com/appengine/>`_, cherrypy_ or any other WSGI_ capable HTTP server.
+* **Server:** Built-in HTTP development server and support for paste_, fapws3_, bjoern_, `Google App Engine <https://cloud.google.com/appengine/>`_, cheroot_ or any other WSGI_ capable HTTP server.
 
 Homepage and documentation: http://bottlepy.org
 

--- a/bottle.py
+++ b/bottle.py
@@ -3287,35 +3287,6 @@ class WSGIRefServer(ServerAdapter):
             raise
 
 
-class CherryPyServer(ServerAdapter):
-    def run(self, handler):  # pragma: no cover
-        depr(0, 13, "The wsgi server part of cherrypy was split into a new "
-                    "project called 'cheroot'.", "Use the 'cheroot' server "
-                    "adapter instead of cherrypy.")
-        from cherrypy import wsgiserver # This will fail for CherryPy >= 9
-
-        self.options['bind_addr'] = (self.host, self.port)
-        self.options['wsgi_app'] = handler
-
-        certfile = self.options.get('certfile')
-        if certfile:
-            del self.options['certfile']
-        keyfile = self.options.get('keyfile')
-        if keyfile:
-            del self.options['keyfile']
-
-        server = wsgiserver.CherryPyWSGIServer(**self.options)
-        if certfile:
-            server.ssl_certificate = certfile
-        if keyfile:
-            server.ssl_private_key = keyfile
-
-        try:
-            server.start()
-        finally:
-            server.stop()
-
-
 class CherootServer(ServerAdapter):
     def run(self, handler): # pragma: no cover
         from cheroot import wsgi
@@ -3557,7 +3528,7 @@ class AiohttpUVLoopServer(AiohttpServer):
 
 class AutoServer(ServerAdapter):
     """ Untested. """
-    adapters = [WaitressServer, PasteServer, TwistedServer, CherryPyServer,
+    adapters = [WaitressServer, PasteServer, TwistedServer,
                 CherootServer, WSGIRefServer]
 
     def run(self, handler):
@@ -3573,7 +3544,7 @@ server_names = {
     'flup': FlupFCGIServer,
     'wsgiref': WSGIRefServer,
     'waitress': WaitressServer,
-    'cherrypy': CherryPyServer,
+    'cherrypy': CherootServer,
     'cheroot': CherootServer,
     'paste': PasteServer,
     'fapws3': FapwsServer,

--- a/docs/_locale/_pot/deployment.pot
+++ b/docs/_locale/_pot/deployment.pot
@@ -65,7 +65,7 @@ msgid "Switching the Server Backend"
 msgstr ""
 
 #: ../../deployment.rst:54
-msgid "The easiest way to increase performance is to install a multi-threaded server library like paste_ or cherrypy_ and tell Bottle to use that instead of the single-threaded default server::"
+msgid "The easiest way to increase performance is to install a multi-threaded server library like paste_ or cheroot_ and tell Bottle to use that instead of the single-threaded default server::"
 msgstr ""
 
 #: ../../deployment.rst:58
@@ -133,7 +133,7 @@ msgid "cherrypy"
 msgstr ""
 
 #: ../../deployment.rst:67
-msgid "cherrypy_"
+msgid "cheroot_"
 msgstr ""
 
 #: ../../deployment.rst:67

--- a/docs/_locale/_pot/index.pot
+++ b/docs/_locale/_pot/index.pot
@@ -37,7 +37,7 @@ msgid "**Utilities:** Convenient access to form data, file uploads, cookies, hea
 msgstr ""
 
 #: ../../index.rst:28
-msgid "**Server:** Built-in HTTP development server and support for paste_, bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
+msgid "**Server:** Built-in HTTP development server and support for paste_, bjoern_, gae_, cheroot_ or any other WSGI_ capable HTTP server."
 msgstr ""
 
 #: ../../index.rst:31

--- a/docs/_locale/_pot/recipes.pot
+++ b/docs/_locale/_pot/recipes.pot
@@ -194,7 +194,7 @@ msgid "Do not cache small files because a disk seek would take longer than on-th
 msgstr ""
 
 #: ../../recipes.rst:232
-msgid "Because of these requirements, it is the recommendation of the Bottle project that Gzip compression is best handled by the WSGI server Bottle runs on top of. WSGI servers such as cherrypy_ provide a GzipFilter_ middleware that can be used to accomplish this."
+msgid "Because of these requirements, it is the recommendation of the Bottle project that Gzip compression is best handled by the WSGI server Bottle runs on top of. WSGI servers such as cheroot_ provide a GzipFilter_ middleware that can be used to accomplish this."
 msgstr ""
 
 #: ../../recipes.rst:236

--- a/docs/_locale/_pot/tutorial.pot
+++ b/docs/_locale/_pot/tutorial.pot
@@ -890,7 +890,7 @@ msgid "Bottle runs on the built-in `wsgiref WSGIServer <http://docs.python.org/l
 msgstr ""
 
 #: ../../tutorial.rst:1036
-msgid "The easiest way to increase performance is to install a multi-threaded server library like paste_ or cherrypy_ and tell Bottle to use that instead of the single-threaded server::"
+msgid "The easiest way to increase performance is to install a multi-threaded server library like paste_ or cheroot_ and tell Bottle to use that instead of the single-threaded server::"
 msgstr ""
 
 #: ../../tutorial.rst:1040

--- a/docs/_locale/_pot/tutorial_app.pot
+++ b/docs/_locale/_pot/tutorial_app.pot
@@ -481,7 +481,7 @@ msgid "As said above, the standard server is perfectly suitable for development,
 msgstr ""
 
 #: ../../tutorial_app.rst:488
-msgid "But Bottle has already various adapters to multi-threaded servers on board, which perform better on higher load. Bottle supports Cherrypy_, Flup_ and Paste_."
+msgid "But Bottle has already various adapters to multi-threaded servers on board, which perform better on higher load. Bottle supports cheroot_, Flup_ and Paste_."
 msgstr ""
 
 #: ../../tutorial_app.rst:490

--- a/docs/_locale/de_DE/LC_MESSAGES/deployment.po
+++ b/docs/_locale/de_DE/LC_MESSAGES/deployment.po
@@ -102,7 +102,7 @@ msgstr ""
 #: ../../deployment.rst:54
 msgid ""
 "The easiest way to increase performance is to install a multi-threaded "
-"server library like paste_ or cherrypy_ and tell Bottle to use that instead "
+"server library like paste_ or cheroot_ and tell Bottle to use that instead "
 "of the single-threaded default server::"
 msgstr ""
 
@@ -173,7 +173,7 @@ msgid "cherrypy"
 msgstr ""
 
 #: ../../deployment.rst:67
-msgid "cherrypy_"
+msgid "cheroot_"
 msgstr ""
 
 #: ../../deployment.rst:67

--- a/docs/_locale/de_DE/LC_MESSAGES/index.po
+++ b/docs/_locale/de_DE/LC_MESSAGES/index.po
@@ -49,7 +49,7 @@ msgstr ""
 #: ../../index.rst:28
 msgid ""
 "**Server:** Built-in HTTP development server and support for paste_, "
-"bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
+"bjoern_, gae_, cheroot_ or any other WSGI_ capable HTTP server."
 msgstr ""
 
 #: ../../index.rst:31

--- a/docs/_locale/de_DE/LC_MESSAGES/recipes.po
+++ b/docs/_locale/de_DE/LC_MESSAGES/recipes.po
@@ -260,7 +260,7 @@ msgstr ""
 msgid ""
 "Because of these requirements, it is the recommendation of the Bottle "
 "project that Gzip compression is best handled by the WSGI server Bottle runs"
-" on top of. WSGI servers such as cherrypy_ provide a GzipFilter_ middleware "
+" on top of. WSGI servers such as cheroot_ provide a GzipFilter_ middleware "
 "that can be used to accomplish this."
 msgstr ""
 

--- a/docs/_locale/de_DE/LC_MESSAGES/tutorial.po
+++ b/docs/_locale/de_DE/LC_MESSAGES/tutorial.po
@@ -1390,7 +1390,7 @@ msgstr ""
 #: ../../tutorial.rst:1036
 msgid ""
 "The easiest way to increase performance is to install a multi-threaded "
-"server library like paste_ or cherrypy_ and tell Bottle to use that instead "
+"server library like paste_ or cheroot_ and tell Bottle to use that instead "
 "of the single-threaded server::"
 msgstr ""
 

--- a/docs/_locale/de_DE/LC_MESSAGES/tutorial_app.po
+++ b/docs/_locale/de_DE/LC_MESSAGES/tutorial_app.po
@@ -773,7 +773,7 @@ msgstr ""
 #: ../../tutorial_app.rst:488
 msgid ""
 "But Bottle has already various adapters to multi-threaded servers on board, "
-"which perform better on higher load. Bottle supports Cherrypy_, Flup_ and "
+"which perform better on higher load. Bottle supports cheroot_, Flup_ and "
 "Paste_."
 msgstr ""
 

--- a/docs/_locale/fr/LC_MESSAGES/deployment.po
+++ b/docs/_locale/fr/LC_MESSAGES/deployment.po
@@ -103,7 +103,7 @@ msgstr ""
 #: ../../deployment.rst:54
 msgid ""
 "The easiest way to increase performance is to install a multi-threaded "
-"server library like paste_ or cherrypy_ and tell Bottle to use that instead "
+"server library like paste_ or cheroot_ and tell Bottle to use that instead "
 "of the single-threaded default server::"
 msgstr ""
 
@@ -174,7 +174,7 @@ msgid "cherrypy"
 msgstr ""
 
 #: ../../deployment.rst:67
-msgid "cherrypy_"
+msgid "cheroot_"
 msgstr ""
 
 #: ../../deployment.rst:67

--- a/docs/_locale/fr/LC_MESSAGES/index.po
+++ b/docs/_locale/fr/LC_MESSAGES/index.po
@@ -50,7 +50,7 @@ msgstr ""
 #: ../../index.rst:28
 msgid ""
 "**Server:** Built-in HTTP development server and support for paste_, "
-"bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
+"bjoern_, gae_, cheroot_ or any other WSGI_ capable HTTP server."
 msgstr ""
 
 #: ../../index.rst:31

--- a/docs/_locale/fr/LC_MESSAGES/recipes.po
+++ b/docs/_locale/fr/LC_MESSAGES/recipes.po
@@ -260,7 +260,7 @@ msgstr ""
 msgid ""
 "Because of these requirements, it is the recommendation of the Bottle "
 "project that Gzip compression is best handled by the WSGI server Bottle runs"
-" on top of. WSGI servers such as cherrypy_ provide a GzipFilter_ middleware "
+" on top of. WSGI servers such as cheroot_ provide a GzipFilter_ middleware "
 "that can be used to accomplish this."
 msgstr ""
 

--- a/docs/_locale/fr/LC_MESSAGES/tutorial.po
+++ b/docs/_locale/fr/LC_MESSAGES/tutorial.po
@@ -1388,7 +1388,7 @@ msgstr ""
 #: ../../tutorial.rst:1036
 msgid ""
 "The easiest way to increase performance is to install a multi-threaded "
-"server library like paste_ or cherrypy_ and tell Bottle to use that instead "
+"server library like paste_ or cheroot_ and tell Bottle to use that instead "
 "of the single-threaded server::"
 msgstr ""
 

--- a/docs/_locale/fr/LC_MESSAGES/tutorial_app.po
+++ b/docs/_locale/fr/LC_MESSAGES/tutorial_app.po
@@ -773,7 +773,7 @@ msgstr ""
 #: ../../tutorial_app.rst:488
 msgid ""
 "But Bottle has already various adapters to multi-threaded servers on board, "
-"which perform better on higher load. Bottle supports Cherrypy_, Flup_ and "
+"which perform better on higher load. Bottle supports cheroot_, Flup_ and "
 "Paste_."
 msgstr ""
 

--- a/docs/_locale/ja_JP/LC_MESSAGES/deployment.po
+++ b/docs/_locale/ja_JP/LC_MESSAGES/deployment.po
@@ -102,7 +102,7 @@ msgstr ""
 #: ../../deployment.rst:54
 msgid ""
 "The easiest way to increase performance is to install a multi-threaded "
-"server library like paste_ or cherrypy_ and tell Bottle to use that instead "
+"server library like paste_ or cheroot_ and tell Bottle to use that instead "
 "of the single-threaded default server::"
 msgstr ""
 
@@ -173,7 +173,7 @@ msgid "cherrypy"
 msgstr ""
 
 #: ../../deployment.rst:67
-msgid "cherrypy_"
+msgid "cheroot_"
 msgstr ""
 
 #: ../../deployment.rst:67

--- a/docs/_locale/ja_JP/LC_MESSAGES/index.po
+++ b/docs/_locale/ja_JP/LC_MESSAGES/index.po
@@ -52,7 +52,7 @@ msgstr "ファイルアップロートやクッキー、ヘッダー、その他
 #: ../../index.rst:28
 msgid ""
 "**Server:** Built-in HTTP development server and support for paste_, "
-"bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
+"bjoern_, gae_, cheroot_ or any other WSGI_ capable HTTP server."
 msgstr ""
 
 #: ../../index.rst:31

--- a/docs/_locale/ja_JP/LC_MESSAGES/recipes.po
+++ b/docs/_locale/ja_JP/LC_MESSAGES/recipes.po
@@ -260,7 +260,7 @@ msgstr ""
 msgid ""
 "Because of these requirements, it is the recommendation of the Bottle "
 "project that Gzip compression is best handled by the WSGI server Bottle runs"
-" on top of. WSGI servers such as cherrypy_ provide a GzipFilter_ middleware "
+" on top of. WSGI servers such as cheroot_ provide a GzipFilter_ middleware "
 "that can be used to accomplish this."
 msgstr ""
 

--- a/docs/_locale/ja_JP/LC_MESSAGES/tutorial.po
+++ b/docs/_locale/ja_JP/LC_MESSAGES/tutorial.po
@@ -1389,7 +1389,7 @@ msgstr ""
 #: ../../tutorial.rst:1036
 msgid ""
 "The easiest way to increase performance is to install a multi-threaded "
-"server library like paste_ or cherrypy_ and tell Bottle to use that instead "
+"server library like paste_ or cheroot_ and tell Bottle to use that instead "
 "of the single-threaded server::"
 msgstr ""
 

--- a/docs/_locale/ja_JP/LC_MESSAGES/tutorial_app.po
+++ b/docs/_locale/ja_JP/LC_MESSAGES/tutorial_app.po
@@ -773,7 +773,7 @@ msgstr ""
 #: ../../tutorial_app.rst:488
 msgid ""
 "But Bottle has already various adapters to multi-threaded servers on board, "
-"which perform better on higher load. Bottle supports Cherrypy_, Flup_ and "
+"which perform better on higher load. Bottle supports cheroot_, Flup_ and "
 "Paste_."
 msgstr ""
 

--- a/docs/_locale/pt_BR/LC_MESSAGES/_pot/deployment.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/_pot/deployment.po
@@ -95,7 +95,7 @@ msgstr ""
 #: ../../deployment.rst:53
 msgid ""
 "The easiest way to increase performance is to install a multi-threaded "
-"server library like paste_ or cherrypy_ and tell Bottle to use that instead "
+"server library like paste_ or cheroot_ and tell Bottle to use that instead "
 "of the single-threaded default server::"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgid "cherrypy"
 msgstr ""
 
 #: ../../deployment.rst:66
-msgid "cherrypy_"
+msgid "cheroot_"
 msgstr ""
 
 #: ../../deployment.rst:66

--- a/docs/_locale/pt_BR/LC_MESSAGES/_pot/index.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/_pot/index.po
@@ -43,7 +43,7 @@ msgstr ""
 #: ../../index.rst:29
 msgid ""
 "**Server:** Built-in HTTP development server and support for paste_, "
-"fapws3_, bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
+"fapws3_, bjoern_, gae_, cheroot_ or any other WSGI_ capable HTTP server."
 msgstr ""
 
 #: ../../index.rst:32

--- a/docs/_locale/pt_BR/LC_MESSAGES/_pot/recipes.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/_pot/recipes.po
@@ -233,7 +233,7 @@ msgstr ""
 msgid ""
 "Because of these requirements, it is the recommendation of the Bottle "
 "project that Gzip compression is best handled by the WSGI server Bottle runs"
-" on top of. WSGI servers such as cherrypy_ provide a GzipFilter_ middleware "
+" on top of. WSGI servers such as cheroot_ provide a GzipFilter_ middleware "
 "that can be used to accomplish this."
 msgstr ""
 

--- a/docs/_locale/pt_BR/LC_MESSAGES/_pot/tutorial.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/_pot/tutorial.po
@@ -1429,7 +1429,7 @@ msgstr ""
 #: ../../tutorial.rst:1048
 msgid ""
 "The easiest way to increase performance is to install a multi-threaded "
-"server library like paste_ or cherrypy_ and tell Bottle to use that instead "
+"server library like paste_ or cheroot_ and tell Bottle to use that instead "
 "of the single-threaded server::"
 msgstr ""
 

--- a/docs/_locale/pt_BR/LC_MESSAGES/_pot/tutorial_app.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/_pot/tutorial_app.po
@@ -793,7 +793,7 @@ msgstr ""
 #: ../../tutorial_app.rst:494
 msgid ""
 "But Bottle has already various adapters to multi-threaded servers on board, "
-"which perform better on higher load. Bottle supports Cherrypy_, Fapws3_, "
+"which perform better on higher load. Bottle supports cheroot_, Fapws3_, "
 "Flup_ and Paste_."
 msgstr ""
 

--- a/docs/_locale/pt_BR/LC_MESSAGES/deployment.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/deployment.po
@@ -102,7 +102,7 @@ msgstr ""
 #: ../../deployment.rst:54
 msgid ""
 "The easiest way to increase performance is to install a multi-threaded "
-"server library like paste_ or cherrypy_ and tell Bottle to use that instead "
+"server library like paste_ or cheroot_ and tell Bottle to use that instead "
 "of the single-threaded default server::"
 msgstr ""
 
@@ -173,7 +173,7 @@ msgid "cherrypy"
 msgstr ""
 
 #: ../../deployment.rst:67
-msgid "cherrypy_"
+msgid "cheroot_"
 msgstr ""
 
 #: ../../deployment.rst:67

--- a/docs/_locale/pt_BR/LC_MESSAGES/index.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/index.po
@@ -53,7 +53,7 @@ msgstr "**Utilitários:** Conveniente acesso a dados de formulários, upload de 
 #: ../../index.rst:28
 msgid ""
 "**Server:** Built-in HTTP development server and support for paste_, "
-"bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
+"bjoern_, gae_, cheroot_ or any other WSGI_ capable HTTP server."
 msgstr ""
 
 #: ../../index.rst:31

--- a/docs/_locale/pt_BR/LC_MESSAGES/recipes.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/recipes.po
@@ -260,7 +260,7 @@ msgstr ""
 msgid ""
 "Because of these requirements, it is the recommendation of the Bottle "
 "project that Gzip compression is best handled by the WSGI server Bottle runs"
-" on top of. WSGI servers such as cherrypy_ provide a GzipFilter_ middleware "
+" on top of. WSGI servers such as cheroot_ provide a GzipFilter_ middleware "
 "that can be used to accomplish this."
 msgstr ""
 

--- a/docs/_locale/pt_BR/LC_MESSAGES/tutorial.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/tutorial.po
@@ -1390,7 +1390,7 @@ msgstr ""
 #: ../../tutorial.rst:1036
 msgid ""
 "The easiest way to increase performance is to install a multi-threaded "
-"server library like paste_ or cherrypy_ and tell Bottle to use that instead "
+"server library like paste_ or cheroot_ and tell Bottle to use that instead "
 "of the single-threaded server::"
 msgstr ""
 

--- a/docs/_locale/pt_BR/LC_MESSAGES/tutorial_app.po
+++ b/docs/_locale/pt_BR/LC_MESSAGES/tutorial_app.po
@@ -773,7 +773,7 @@ msgstr ""
 #: ../../tutorial_app.rst:488
 msgid ""
 "But Bottle has already various adapters to multi-threaded servers on board, "
-"which perform better on higher load. Bottle supports Cherrypy_, Flup_ and "
+"which perform better on higher load. Bottle supports cheroot_, Flup_ and "
 "Paste_."
 msgstr ""
 

--- a/docs/_locale/ru_RU/LC_MESSAGES/deployment.po
+++ b/docs/_locale/ru_RU/LC_MESSAGES/deployment.po
@@ -102,7 +102,7 @@ msgstr ""
 #: ../../deployment.rst:54
 msgid ""
 "The easiest way to increase performance is to install a multi-threaded "
-"server library like paste_ or cherrypy_ and tell Bottle to use that instead "
+"server library like paste_ or cheroot_ and tell Bottle to use that instead "
 "of the single-threaded default server::"
 msgstr ""
 
@@ -173,7 +173,7 @@ msgid "cherrypy"
 msgstr ""
 
 #: ../../deployment.rst:67
-msgid "cherrypy_"
+msgid "cheroot_"
 msgstr ""
 
 #: ../../deployment.rst:67

--- a/docs/_locale/ru_RU/LC_MESSAGES/index.po
+++ b/docs/_locale/ru_RU/LC_MESSAGES/index.po
@@ -49,7 +49,7 @@ msgstr ""
 #: ../../index.rst:28
 msgid ""
 "**Server:** Built-in HTTP development server and support for paste_, "
-"bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
+"bjoern_, gae_, cheroot_ or any other WSGI_ capable HTTP server."
 msgstr ""
 
 #: ../../index.rst:31

--- a/docs/_locale/ru_RU/LC_MESSAGES/recipes.po
+++ b/docs/_locale/ru_RU/LC_MESSAGES/recipes.po
@@ -260,7 +260,7 @@ msgstr ""
 msgid ""
 "Because of these requirements, it is the recommendation of the Bottle "
 "project that Gzip compression is best handled by the WSGI server Bottle runs"
-" on top of. WSGI servers such as cherrypy_ provide a GzipFilter_ middleware "
+" on top of. WSGI servers such as cheroot_ provide a GzipFilter_ middleware "
 "that can be used to accomplish this."
 msgstr ""
 

--- a/docs/_locale/ru_RU/LC_MESSAGES/tutorial.po
+++ b/docs/_locale/ru_RU/LC_MESSAGES/tutorial.po
@@ -1389,7 +1389,7 @@ msgstr ""
 #: ../../tutorial.rst:1036
 msgid ""
 "The easiest way to increase performance is to install a multi-threaded "
-"server library like paste_ or cherrypy_ and tell Bottle to use that instead "
+"server library like paste_ or cheroot_ and tell Bottle to use that instead "
 "of the single-threaded server::"
 msgstr ""
 

--- a/docs/_locale/ru_RU/LC_MESSAGES/tutorial_app.po
+++ b/docs/_locale/ru_RU/LC_MESSAGES/tutorial_app.po
@@ -773,7 +773,7 @@ msgstr ""
 #: ../../tutorial_app.rst:488
 msgid ""
 "But Bottle has already various adapters to multi-threaded servers on board, "
-"which perform better on higher load. Bottle supports Cherrypy_, Flup_ and "
+"which perform better on higher load. Bottle supports cheroot_, Flup_ and "
 "Paste_."
 msgstr ""
 

--- a/docs/_locale/zh_CN/LC_MESSAGES/_pot/deployment.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/_pot/deployment.po
@@ -95,7 +95,7 @@ msgstr ""
 #: ../../deployment.rst:53
 msgid ""
 "The easiest way to increase performance is to install a multi-threaded "
-"server library like paste_ or cherrypy_ and tell Bottle to use that instead "
+"server library like paste_ or cheroot_ and tell Bottle to use that instead "
 "of the single-threaded default server::"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgid "cherrypy"
 msgstr ""
 
 #: ../../deployment.rst:66
-msgid "cherrypy_"
+msgid "cheroot_"
 msgstr ""
 
 #: ../../deployment.rst:66

--- a/docs/_locale/zh_CN/LC_MESSAGES/_pot/index.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/_pot/index.po
@@ -43,7 +43,7 @@ msgstr ""
 #: ../../index.rst:29
 msgid ""
 "**Server:** Built-in HTTP development server and support for paste_, "
-"fapws3_, bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
+"fapws3_, bjoern_, gae_, cheroot_ or any other WSGI_ capable HTTP server."
 msgstr ""
 
 #: ../../index.rst:32

--- a/docs/_locale/zh_CN/LC_MESSAGES/_pot/recipes.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/_pot/recipes.po
@@ -233,7 +233,7 @@ msgstr ""
 msgid ""
 "Because of these requirements, it is the recommendation of the Bottle "
 "project that Gzip compression is best handled by the WSGI server Bottle runs"
-" on top of. WSGI servers such as cherrypy_ provide a GzipFilter_ middleware "
+" on top of. WSGI servers such as cheroot_ provide a GzipFilter_ middleware "
 "that can be used to accomplish this."
 msgstr ""
 

--- a/docs/_locale/zh_CN/LC_MESSAGES/_pot/tutorial.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/_pot/tutorial.po
@@ -1429,7 +1429,7 @@ msgstr ""
 #: ../../tutorial.rst:1048
 msgid ""
 "The easiest way to increase performance is to install a multi-threaded "
-"server library like paste_ or cherrypy_ and tell Bottle to use that instead "
+"server library like paste_ or cheroot_ and tell Bottle to use that instead "
 "of the single-threaded server::"
 msgstr ""
 

--- a/docs/_locale/zh_CN/LC_MESSAGES/_pot/tutorial_app.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/_pot/tutorial_app.po
@@ -793,7 +793,7 @@ msgstr ""
 #: ../../tutorial_app.rst:494
 msgid ""
 "But Bottle has already various adapters to multi-threaded servers on board, "
-"which perform better on higher load. Bottle supports Cherrypy_, Fapws3_, "
+"which perform better on higher load. Bottle supports cheroot_, Fapws3_, "
 "Flup_ and Paste_."
 msgstr ""
 

--- a/docs/_locale/zh_CN/LC_MESSAGES/deployment.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/deployment.po
@@ -102,7 +102,7 @@ msgstr "更改服务器后端"
 #: ../../deployment.rst:54
 msgid ""
 "The easiest way to increase performance is to install a multi-threaded "
-"server library like paste_ or cherrypy_ and tell Bottle to use that instead "
+"server library like paste_ or cheroot_ and tell Bottle to use that instead "
 "of the single-threaded default server::"
 msgstr ""
 
@@ -173,7 +173,7 @@ msgid "cherrypy"
 msgstr ""
 
 #: ../../deployment.rst:67
-msgid "cherrypy_"
+msgid "cheroot_"
 msgstr ""
 
 #: ../../deployment.rst:67

--- a/docs/_locale/zh_CN/LC_MESSAGES/index.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/index.po
@@ -50,7 +50,7 @@ msgstr "**基础功能(Utilities):** 方便地访问表单数据，上传文件�
 #: ../../index.rst:28
 msgid ""
 "**Server:** Built-in HTTP development server and support for paste_, "
-"bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server."
+"bjoern_, gae_, cheroot_ or any other WSGI_ capable HTTP server."
 msgstr ""
 
 #: ../../index.rst:31

--- a/docs/_locale/zh_CN/LC_MESSAGES/recipes.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/recipes.po
@@ -260,9 +260,9 @@ msgstr "不缓存小文件，因为寻道时间或许比压缩时间还长"
 msgid ""
 "Because of these requirements, it is the recommendation of the Bottle "
 "project that Gzip compression is best handled by the WSGI server Bottle runs"
-" on top of. WSGI servers such as cherrypy_ provide a GzipFilter_ middleware "
+" on top of. WSGI servers such as cheroot_ provide a GzipFilter_ middleware "
 "that can be used to accomplish this."
-msgstr "因为有上述种种限制，建议由WSGI服务器来处理Gzip压缩而不是Bottle。像 cherrypy_ 就提供了一个 GzipFilter_ 中间件来处理Gzip压缩。"
+msgstr "因为有上述种种限制，建议由WSGI服务器来处理Gzip压缩而不是Bottle。像 cheroot_ 就提供了一个 GzipFilter_ 中间件来处理Gzip压缩。"
 
 #: ../../recipes.rst:236
 msgid "Using the hooks plugin"

--- a/docs/_locale/zh_CN/LC_MESSAGES/tutorial.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/tutorial.po
@@ -1388,9 +1388,9 @@ msgstr ""
 #: ../../tutorial.rst:1036
 msgid ""
 "The easiest way to increase performance is to install a multi-threaded "
-"server library like paste_ or cherrypy_ and tell Bottle to use that instead "
+"server library like paste_ or cheroot_ and tell Bottle to use that instead "
 "of the single-threaded server::"
-msgstr "最早的解决办法是让Bottle使用 paste_ 或 cherrypy_ 等多线程的服务器。"
+msgstr "最早的解决办法是让Bottle使用 paste_ 或 cheroot_ 等多线程的服务器。"
 
 #: ../../tutorial.rst:1040
 msgid ""

--- a/docs/_locale/zh_CN/LC_MESSAGES/tutorial_app.po
+++ b/docs/_locale/zh_CN/LC_MESSAGES/tutorial_app.po
@@ -773,7 +773,7 @@ msgstr "在大型项目上，Bottle自带的服务器会成为一个性能瓶颈
 #: ../../tutorial_app.rst:488
 msgid ""
 "But Bottle has already various adapters to multi-threaded servers on board, "
-"which perform better on higher load. Bottle supports Cherrypy_, Flup_ and "
+"which perform better on higher load. Bottle supports cheroot_, Flup_ and "
 "Paste_."
 msgstr ""
 

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -1,7 +1,7 @@
 .. _flup: http://trac.saddi.com/flup
 .. _gae: http://code.google.com/appengine/docs/python/overview.html
 .. _wsgiref: http://docs.python.org/library/wsgiref.html
-.. _cherrypy: http://www.cherrypy.org/
+.. _cheroot: https://cheroot.rtfd.io/
 .. _paste: http://pythonpaste.org/
 .. _gunicorn: http://pypi.python.org/pypi/gunicorn
 .. _tornado: http://www.tornadoweb.org/
@@ -51,7 +51,7 @@ The built-in default server is based on `wsgiref WSGIServer <http://docs.python.
 Switching the Server Backend
 ================================================================================
 
-The easiest way to increase performance is to install a multi-threaded server library like paste_ or cherrypy_ and tell Bottle to use that instead of the single-threaded default server::
+The easiest way to increase performance is to install a multi-threaded server library like paste_ or cheroot_ and tell Bottle to use that instead of the single-threaded default server::
 
     run(server='paste')
 
@@ -64,7 +64,7 @@ cgi                     Run as CGI script
 flup      flup_         Run as FastCGI process
 gae       gae_          Helper for Google App Engine deployments
 wsgiref   wsgiref_      Single-threaded default server
-cherrypy  cherrypy_     Multi-threaded and very stable
+cheroot   cheroot_      Multi-threaded and very stable
 paste     paste_        Multi-threaded, stable, tried and tested
 waitress  waitress_     Multi-threaded, poweres Pyramid
 gunicorn  gunicorn_     Pre-forked, partly written in C

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@
 .. _paste: http://pythonpaste.org/
 .. _bjoern: https://github.com/jonashaag/bjoern
 .. _flup: http://trac.saddi.com/flup
-.. _cherrypy: http://www.cherrypy.org/
+.. _cheroot: https://cheroot.rtfd.io/
 .. _WSGI: http://www.wsgi.org/
 .. _Python: http://python.org/
 .. _testing: https://github.com/bottlepy/bottle/raw/master/bottle.py
@@ -25,7 +25,7 @@ Bottle is a fast, simple and lightweight WSGI_ micro web-framework for Python_. 
 * **Routing:** Requests to function-call mapping with support for clean and  dynamic URLs.
 * **Templates:** Fast and pythonic :ref:`built-in template engine <tutorial-templates>` and support for mako_, jinja2_ and cheetah_ templates.
 * **Utilities:** Convenient access to form data, file uploads, cookies, headers and other HTTP-related metadata.
-* **Server:** Built-in HTTP development server and support for paste_, bjoern_, gae_, cherrypy_ or any other WSGI_ capable HTTP server.
+* **Server:** Built-in HTTP development server and support for paste_, bjoern_, gae_, cheroot_ or any other WSGI_ capable HTTP server.
 
 .. rubric:: Example: "Hello World" in a bottle
 

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -8,8 +8,7 @@
 .. _pylons: http://pylonshq.com/
 .. _gevent: http://www.gevent.org/
 .. _compression: https://github.com/bottlepy/bottle/issues/92
-.. _GzipFilter: http://www.cherrypy.org/wiki/GzipFilter
-.. _cherrypy: http://www.cherrypy.org
+.. _cheroot: http://www.cherrypy.org
 .. _heroku: http://heroku.com
 
 Recipes
@@ -229,7 +228,7 @@ Supporting Gzip compression is not a straightforward proposition, due to a numbe
 * Make sure the cache does not get to big.
 * Do not cache small files because a disk seek would take longer than on-the-fly compression.
 
-Because of these requirements, it is the recommendation of the Bottle project that Gzip compression is best handled by the WSGI server Bottle runs on top of. WSGI servers such as cherrypy_ provide a GzipFilter_ middleware that can be used to accomplish this.
+Because of these requirements, it is the recommendation of the Bottle project that Gzip compression is best handled by the WSGI server Bottle runs on top of. WSGI servers such as cheroot_ provide a GzipFilter_ middleware that can be used to accomplish this.
 
 
 Using the hooks plugin

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -2,7 +2,7 @@
 
 .. _Apache Server:
 .. _Apache: http://www.apache.org/
-.. _cherrypy: http://www.cherrypy.org/
+.. _cheroot: https://cheroot.rtfd.io/
 .. _decorator: http://docs.python.org/glossary.html#term-decorator
 .. _flup: http://trac.saddi.com/flup
 .. _http_code: http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
@@ -1033,7 +1033,7 @@ Deployment
 
 Bottle runs on the built-in `wsgiref WSGIServer <http://docs.python.org/library/wsgiref.html#module-wsgiref.simple_server>`_  by default. This non-threading HTTP server is perfectly fine for development, but may become a performance bottleneck when server load increases.
 
-The easiest way to increase performance is to install a multi-threaded server library like paste_ or cherrypy_ and tell Bottle to use that instead of the single-threaded server::
+The easiest way to increase performance is to install a multi-threaded server library like paste_ or cheroot_ and tell Bottle to use that instead of the single-threaded server::
 
     bottle.run(server='paste')
 

--- a/docs/tutorial_app.rst
+++ b/docs/tutorial_app.rst
@@ -6,7 +6,7 @@
 .. _`decorator statement`: http://docs.python.org/glossary.html#term-decorator
 .. _`Python DB API`: http://www.python.org/dev/peps/pep-0249/
 .. _`WSGI reference Server`: http://docs.python.org/library/wsgiref.html#module-wsgiref.simple_server
-.. _Cherrypy: http://www.cherrypy.org/
+.. _cheroot: https://cheroot.rtfd.io/
 .. _Flup: https://www.saddi.com/software/flup/
 .. _Paste: http://pythonpaste.org/
 .. _Apache: http://www.apache.org
@@ -485,7 +485,7 @@ The ``port`` and ``host`` parameter can also be applied when Bottle is running w
 
 As said above, the standard server is perfectly suitable for development, personal use or a small group of people only using your application based on Bottle. For larger tasks, the standard server may become a bottleneck, as it is single-threaded, thus it can only serve one request at a time.
 
-But Bottle has already various adapters to multi-threaded servers on board, which perform better on higher load. Bottle supports Cherrypy_, Flup_ and Paste_.
+But Bottle has already various adapters to multi-threaded servers on board, which perform better on higher load. Bottle supports cheroot_, Flup_ and Paste_.
 
 If you want to run for example Bottle with the Paste server, use the following code::
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ basepython=python2.7
 deps=Mako
      jinja2
      eventlet
-     cherrypy
+     cheroot
      paste
      twisted
      tornado


### PR DESCRIPTION
Hi @defnull,

This `PR` completely remove `cherrypy` usage.

It :
+ [x] Removes cherrypy as backend server (code is removed, but using it as backend server will start **cheroot**) ℹ️ Not sure there is a lot of people using cherrypy < 9 , btw this version this backend could not be used with cherrypy >= 9
+ [x] Updates doc link

⚠️ I'm not sure **cheroot** includes any `GZip` feature

Regards,

-------
Closes #934 
Closes #975 
Closes #426 