### PR TITLE
Fix handling of empty If-Modified-Since header for static files

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2928,8 +2928,8 @@ def static_file(filename, root,
     ims = getenv('HTTP_IF_MODIFIED_SINCE')
     if ims:
         ims = parse_date(ims.split(";")[0].strip())
-    if ims is not None and ims >= int(stats.st_mtime):
-        return HTTPResponse(status=304, **headers)
+        if ims is not None and ims >= int(stats.st_mtime):
+            return HTTPResponse(status=304, **headers)
 
     body = '' if request.method == 'HEAD' else open(filename, 'rb')
 

--- a/test/test_sendfile.py
+++ b/test/test_sendfile.py
@@ -95,6 +95,11 @@ class TestSendFile(unittest.TestCase):
         request.environ['HTTP_IF_MODIFIED_SINCE'] = bottle.http_date(100)
         self.assertEqual(open(__file__,'rb').read(), static_file(basename, root=root).body.read())
 
+    def test_ims_empty(self):
+        """ SendFile: Empty If-Modified-Since"""
+        request.environ['HTTP_IF_MODIFIED_SINCE'] = ''
+        self.assertEqual(open(__file__, 'rb').read(), static_file(basename, root=root).body.read())
+
     def test_etag(self):
         """ SendFile: If-Modified-Since"""
         res = static_file(basename, root=root)


### PR DESCRIPTION
Previously, if the If-Modified-Since header was an empty string it wouldn't be parsed into an int (or None), but would still be compared to the int mtime, causing a TypeError.