### PR TITLE
Removed a pitfall where the code was using a default mutable argument

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -210,7 +210,7 @@ class DictProperty(object):
         self.attr, self.key, self.read_only = attr, key, read_only
 
     def __call__(self, func):
-        functools.update_wrapper(self, func, updated=None)
+        functools.update_wrapper(self, func, updated=[])
         if updated is None:
             updated = []
         self.getter, self.key = func, self.key or func.__name__


### PR DESCRIPTION
**The problem**
In Python it usually dangerous to use mutable arguments like dicts or lists as default arguments in method, as is better explained [here](https://docs.python-guide.org/writing/gotchas/)

**the solution**
This PR applies a simple refactoring to remove a case where a method was created using default a mutable argument