### PR TITLE
Fix #1359: check for attribute using hasattr

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1594,7 +1594,7 @@ class BaseRequest(object):
     def __setattr__(self, name, value):
         if name == 'environ': return object.__setattr__(self, name, value)
         key = 'bottle.request.ext.%s' % name
-        if key in self.environ:
+        if hasattr(self, name):
             raise AttributeError("Attribute already defined: %s" % name)
         self.environ[key] = value
 

--- a/test/test_environ.py
+++ b/test/test_environ.py
@@ -462,6 +462,9 @@ class TestRequest(unittest.TestCase):
             # Attributes are read-only once set.
             self.assertRaises(AttributeError, setattr, r, 'foo', 'x')
 
+            # Properties raise AttributeError.
+            self.assertRaises(AttributeError, setattr, r, 'body', 'x')
+
             # Unknown attributes raise AttributeError.
             self.assertRaises(AttributeError, getattr, r, 'somevalue')
 


### PR DESCRIPTION
This PR fixes a bug where setting an existing, read-only property of a BaseRequest object does not raise an AttributeError.

Fixes #1359