### PR TITLE
Add an optional redirect(cache=sec) argument

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2813,13 +2813,15 @@ def abort(code=500, text='Unknown Error.'):
     raise HTTPError(code, text)
 
 
-def redirect(url, code=None):
+def redirect(url, code=None, cache=None):
     """ Aborts execution and causes a 303 or 302 redirect, depending on
         the HTTP protocol version. """
     if not code:
         code = 303 if request.get('SERVER_PROTOCOL') == "HTTP/1.1" else 302
     res = response.copy(cls=HTTPResponse)
     res.status = code
+    if type(cache) is int:
+        res.set_header('Cache-Control', 'max-age=%s' % cache)
     res.body = ""
     res.set_header('Location', urljoin(request.url, url))
     raise res


### PR DESCRIPTION
The argument sets an optional `Cache-Control` header for redirects. Allows for more fined-grained control over client and browser caching for known short- and long-lived redirects. The argument accepts an integer value with the number of seconds to add to the `max-age` directive.