### PR TITLE
fixes #580 and makes it "fit"

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2843,8 +2843,7 @@ def static_file(filename, root,
                 mimetype=True,
                 download=False,
                 charset='UTF-8',
-                etag=None,
-                headers=None):
+                etag=None):
     """ Open a file in a safe way and return an instance of :exc:`HTTPResponse`
         that can be sent back to the client.
 
@@ -2861,7 +2860,7 @@ def static_file(filename, root,
             (default: UTF-8)
         :param etag: Provide a pre-computed ETag header. If set to ``False``,
             ETag handling is disabled. (default: auto-generate ETag header)
-        :param headers: Additional headers dict to add to the response.
+        
 
         While checking user input is always a good idea, this function provides
         additional protection against malicious ``filename`` parameters from
@@ -2879,7 +2878,7 @@ def static_file(filename, root,
 
     root = os.path.join(os.path.abspath(root), '')
     filename = os.path.abspath(os.path.join(root, filename.strip('/\\')))
-    headers = headers.copy() if headers else {}
+    headers = response.headers
 
     if not filename.startswith(root):
         return HTTPError(403, "Access denied.")


### PR DESCRIPTION
This fixes #580 

It seems the current release and the dev versions are different.  This dev version adds a headers kwarg, which is not how the rest of bottle works, which uses `response.headers()`.  This fixes #580, which was already, somewhat fixed, but also changes it to not need a headers kwarg, just copy from the existing response headers.

Either way, you can close #580 now.