### PR TITLE
updated web links for pythonpaste and cherrypy projects

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -1,8 +1,8 @@
 .. _flup: http://trac.saddi.com/flup
 .. _gae: http://code.google.com/appengine/docs/python/overview.html
 .. _wsgiref: http://docs.python.org/library/wsgiref.html
-.. _cherrypy: http://www.cherrypy.org/
-.. _paste: http://pythonpaste.readthedocs.io/
+.. _cherrypy: https://cherrypy.dev/
+.. _paste: https://pythonpaste.readthedocs.io/
 .. _gunicorn: http://pypi.python.org/pypi/gunicorn
 .. _tornado: http://www.tornadoweb.org/
 .. _twisted: http://twistedmatrix.com/

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -2,7 +2,7 @@
 
 .. _Apache Server:
 .. _Apache: http://www.apache.org/
-.. _cherrypy: http://www.cherrypy.org/
+.. _cherrypy: https://cherrypy.dev/
 .. _decorator: http://docs.python.org/glossary.html#term-decorator
 .. _flup: http://trac.saddi.com/flup
 .. _http_code: http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
@@ -11,7 +11,7 @@
 .. _lighttpd: http://www.lighttpd.net/
 .. _mako: http://www.makotemplates.org/
 .. _mod_wsgi: http://code.google.com/p/modwsgi/
-.. _Paste: http://pythonpaste.org/
+.. _Paste: https://pythonpaste.readthedocs.io
 .. _Pound: http://www.apsis.ch/pound/
 .. _WSGI_Specification: http://www.wsgi.org/
 .. _issue: http://github.com/bottlepy/bottle/issues

--- a/docs/tutorial_app.rst
+++ b/docs/tutorial_app.rst
@@ -6,9 +6,9 @@
 .. _`decorator statement`: http://docs.python.org/glossary.html#term-decorator
 .. _`Python DB API`: http://www.python.org/dev/peps/pep-0249/
 .. _`WSGI reference Server`: http://docs.python.org/library/wsgiref.html#module-wsgiref.simple_server
-.. _Cherrypy: http://www.cherrypy.org/
+.. _Cherrypy: https://cherrypy.dev/
 .. _Flup: https://www.saddi.com/software/flup/
-.. _Paste: http://pythonpaste.org/
+.. _Paste: https://pythonpaste.readthedocs.io
 .. _Apache: http://www.apache.org
 .. _`Bottle documentation`: http://bottlepy.org/docs/dev/tutorial.html
 .. _`mod_wsgi`: http://code.google.com/p/modwsgi/


### PR DESCRIPTION
I edited the links tutorial files for cherrypy project
so they point to the right webresource cherrypy.dev
I also updated the recently updated web reference for pythonpaste, with https, 
and updated the reference where it was missing.