### PR TITLE
rename TestError to ExampleError to avoid PytestCollectionWarning

### DIFF
--- a/test/test_exc.py
+++ b/test/test_exc.py
@@ -1,7 +1,7 @@
 import bottle
 from .tools import ServerTestBase
 
-class TestError(Exception):
+class ExampleError(Exception):
     pass
 
 class TestAppException(ServerTestBase):
@@ -18,13 +18,13 @@ class TestAppException(ServerTestBase):
 
     def test_other_error(self):
         @bottle.route('/')
-        def test(): raise TestError
-        self.assertRaises(TestError)
+        def test(): raise ExampleError
+        self.assertRaises(ExampleError)
 
     def test_noncatched_error(self):
         @bottle.route('/')
-        def test(): raise TestError
+        def test(): raise ExampleError
         bottle.request.environ['exc_info'] = None
         bottle.catchall = False
         self.assertStatus(500, '/')
-        self.assertInBody('TestError')
+        self.assertInBody('ExampleError')


### PR DESCRIPTION
When running tests, this warning is raised:

```
test/test_exc.py:4
  /Users/dani/bottle/test/test_exc.py:4: PytestCollectionWarning: cannot collect test class 'TestError' because it has a __init__ constructor (from: test/test_exc.py)
    class TestError(Exception):
```

this is because pytest is trying to collect all classes starting with the word `Test`. Since this class isn't an actual test, renaming it to something else is appropriate. 
Another solution would've been to add `  __test__ = False` to the class, but renaming seemed straight-forward.

It's always nice to run tests and not see warnings, so I may fix some more in upcoming PRs :) 