### PR TITLE
Backport fixes for #1155 and #1194 catastrophic regex backtracking issues to the 0.12 release branch

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3486,7 +3486,7 @@ class StplParser(object):
     # Match the start tokens of code areas in a template
     _re_split = '(?m)^[ \t]*(\\\\?)((%(line_start)s)|(%(block_start)s))(%%?)'
     # Match inline statements (may contain python strings)
-    _re_inl = '(?m)%%(inline_start)s((?:%s|[^\'"\n]*?)+)%%(inline_end)s' % _re_inl
+    _re_inl = '(?m)%%(inline_start)s((?:%s|[^\'"\n])*?)%%(inline_end)s' % _re_inl
     _re_tok = '(?m)' + _re_tok
 
     default_syntax = '<% %> % {{ }}'

--- a/bottle.py
+++ b/bottle.py
@@ -308,7 +308,7 @@ class Router(object):
     rule_syntax = re.compile('(\\\\*)'\
         '(?:(?::([a-zA-Z_][a-zA-Z_0-9]*)?()(?:#(.*?)#)?)'\
           '|(?:<([a-zA-Z_][a-zA-Z_0-9]*)?(?::([a-zA-Z_]*)'\
-            '(?::((?:\\\\.|[^\\\\>]+)+)?)?)?>))')
+            '(?::((?:\\\\.|[^\\\\>])+)?)?)?>))')
 
     def _itertokens(self, rule):
         offset, prefix = 0, ''


### PR DESCRIPTION
Hello, this change is intended to resolve these issues for those using the officially released 0.12 branch. I've verified both of the fixes as outlined in the two commits here, adapting the changes to the older branch.