### PR TITLE
docs/index.rst: Fix broken link: cherrypy.org -> cherrypy.dev

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@
 .. _paste: http://pythonpaste.org/
 .. _bjoern: https://github.com/jonashaag/bjoern
 .. _flup: http://trac.saddi.com/flup
-.. _cherrypy: http://www.cherrypy.org/
+.. _cherrypy: http://www.cherrypy.dev/
 .. _WSGI: http://www.wsgi.org/
 .. _Python: http://python.org/
 .. _testing: https://github.com/bottlepy/bottle/raw/master/bottle.py


### PR DESCRIPTION
Hi there,
cherrypy.org is some random french site. :smiling_face_with_tear: 
cherrypy.dev is the right one.
Thanks,
Sergei