### PR TITLE
Avoid KeyError: 'PATH_INFO' errors

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -453,7 +453,7 @@ class Router(object):
     def match(self, environ):
         """ Return a (target, url_args) tuple or raise HTTPError(400/404/405). """
         verb = environ['REQUEST_METHOD'].upper()
-        path = environ['PATH_INFO'] or '/'
+        path = environ.get('PATH_INFO') or '/'
 
         methods = ('PROXY', 'HEAD', 'GET', 'ANY') if verb == 'HEAD' else ('PROXY', verb, 'ANY')
 
@@ -963,7 +963,7 @@ class Bottle(object):
         return tob(template(ERROR_PAGE_TEMPLATE, e=res, template_settings=dict(name='__ERROR_PAGE_TEMPLATE')))
 
     def _handle(self, environ):
-        path = environ['bottle.raw_path'] = environ['PATH_INFO']
+        path = environ['bottle.raw_path'] = environ.get('PATH_INFO') or '/'
         if py3k:
             environ['PATH_INFO'] = path.encode('latin1').decode('utf8', 'ignore')
 
@@ -1104,7 +1104,7 @@ class Bottle(object):
         except Exception as E:
             if not self.catchall: raise
             err = '<h1>Critical error while processing request: %s</h1>' \
-                  % html_escape(environ.get('PATH_INFO', '/'))
+                  % html_escape(environ.get('PATH_INFO') or '/')
             if DEBUG:
                 err += '<h2>Error:</h2>\n<pre>\n%s\n</pre>\n' \
                        '<h2>Traceback:</h2>\n<pre>\n%s\n</pre>\n' \


### PR DESCRIPTION
I use bottle often and in many of the applications I get frequent tracebacks:
```
Traceback (most recent call last):
  File "/src/pvoproxy/venv/lib/python3.11/site-packages/bottle.py", line 863, in _handle
     path = environ['bottle.raw_path'] = environ['PATH_INFO']
                                         ~~~~~~~^^^^^^^^^^^^^
KeyError: 'PATH_INFO'
```

This PR fixes that.

