### PR TITLE
Fix #1350: Serve compresed files as is in static_file()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -74,8 +74,8 @@ These changes might require special care when updating.
 * :meth:`Bottle.mount` now recognizes instances of :class:`Bottle` and mounts them with significantly less overhead than other WSGI applications.
 * The :attr:`BaseRequest.json` property now accepts ``application/json-rpc`` requests.
 * :func:`static_file` gained support for ``ETag`` headers. It will generate ETags and recognizes ``If-None-Match`` headers.
+* :func:`static_file` will now guess the mime type of ``*.gz`` and other compressed files correctly (e.g. ``application/gzip``) and NOT set the ``Content-Encoding`` header.
 * Jinja2 templates will produce better error messages than before.
-
 
 
 

--- a/test/test_sendfile.py
+++ b/test/test_sendfile.py
@@ -85,6 +85,17 @@ class TestSendFile(unittest.TestCase):
         f = static_file(basename, root=root, mimetype='text/foo', charset='latin1')
         self.assertEqual('text/foo; charset=latin1', f.headers['Content-Type'])
 
+    def test_mime_gzip(self):
+        """ SendFile: Mime Guessing"""
+        try:
+            fp, fn = tempfile.mkstemp(suffix=".txt.gz")
+            f = static_file(fn, root='/')
+            self.assertTrue(f.headers['Content-Type'][0] in ('application/gzip'))
+            self.assertFalse('Content-Encoding' in f.headers)
+        finally:
+            os.close(fp)
+            os.unlink(fn)
+
     def test_ims(self):
         """ SendFile: If-Modified-Since"""
         request.environ['HTTP_IF_MODIFIED_SINCE'] = bottle.http_date(time.time())
@@ -118,7 +129,6 @@ class TestSendFile(unittest.TestCase):
         self.assertTrue('ETag' in res.headers)
         self.assertNotEqual(etag, res.headers['ETag'])
         self.assertEqual(200, res.status_code)
-       
 
     def test_download(self):
         """ SendFile: Download as attachment """


### PR DESCRIPTION
Do not instruct browsers to transparently uncompress gzipped files.