### PR TITLE
Include the captured exception on invalid JSON

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1277,8 +1277,8 @@ class BaseRequest(object):
                 return None
             try:
                 return json_loads(b)
-            except (ValueError, TypeError):
-                raise HTTPError(400, 'Invalid JSON')
+            except (ValueError, TypeError) as err:
+                raise HTTPError(400, 'Invalid JSON', exception=err)
         return None
 
     def _iter_body(self, read, bufsize):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ Release 0.14 (in development)
 .. rubric:: Removed APIs (deprecated since 0.13)
 
 * Removed the ``RouteReset`` exception and associated logic.
+* ``bottle.HTTPError``\s raised on Invalid JSON now include the underlying exception
+  in their ``exception`` field.
 
 Release 0.13
 ==============


### PR DESCRIPTION
I encountered this as an issue while handling the bottle 0.13 update from 0.12.
The behavior of JSON decoding failures has changed slightly vs 0.12, and while updating I was surprised to find that `error.exception` was unset, when a JSONDecodeError was caught.

Setting the inner exception to the caught exception helps callers catch and re-emit JSON decoding errors with their own code (e.g., to meet error API standards for their application).

---

Please let me know if this PR is missing anything it needs to progress.
I'm happy to take extra steps (add new tests, sign a CLA, etc) as appropriate.
