### PR TITLE
Deprecate bottle.py script install

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -4671,5 +4671,9 @@ def _main(argv):  # pragma: no coverage
         config=config)
 
 
-if __name__ == '__main__':  # pragma: no coverage
+def main():
     _main(sys.argv)
+
+
+if __name__ == '__main__':  # pragma: no coverage
+    main()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,7 @@ versions should not update to Bottle 0.13 and stick with 0.12 instead.
 
 .. rubric:: Deprecated APIs
 
+* Python 2 support is now deprecated and will be dropped with the next release.
 * The old route syntax (``/hello/:name``) is deprecated in favor of the more readable and flexible ``/hello/<name>`` syntax.
 * :meth:`Bottle.mount` now recognizes Bottle instance and will warn about parameters that are not compatible with the new mounting behavior. The old behavior (mount applications as WSGI callable) still works and is used as a fallback automatically.
 * The undocumented :func:`local_property` helper is now deprecated.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,7 @@ versions should not update to Bottle 0.13 and stick with 0.12 instead.
 .. rubric:: Deprecated APIs
 
 * Python 2 support is now deprecated and will be dropped with the next release.
+* The command line executable installed along with bottle will be renamed from `bottle.py` to just `bottle`. You can still execute bottle directly as a script (e.g. `./bottle.py` or `python3 bottle.py`) or as a module (via `python3 -m bottle`). Just the executable installed by your packaging tool (e.g. `pip`) into the `bin` folder of your (virtual) environment will change.
 * The old route syntax (``/hello/:name``) is deprecated in favor of the more readable and flexible ``/hello/<name>`` syntax.
 * :meth:`Bottle.mount` now recognizes Bottle instance and will warn about parameters that are not compatible with the new mounting behavior. The old behavior (mount applications as WSGI callable) still works and is used as a fallback automatically.
 * The undocumented :func:`local_property` helper is now deprecated.
@@ -65,6 +66,7 @@ These changes might require special care when updating.
 
 * Signed cookies now use a stronger HMAC algorithm by default. This will result in old cookies to appear invalid after the update. Pass an explicit ``digestmod=hashlib.md5`` to :meth:`BaseRequest.get_cookie` and :meth:`BaseResponse.set_cookie` to get the old behavior.
 * Bottle now ships with its own multipart form data parser (borrowed from `multipart <https://pypi.org/project/multipart/>`_) and no longer relies on ``cgi.FieldStorage``, which was removed in Python 3.13. This may change the way broken (non-standard) form submissions are parsed. The new parser is more strict and correct than ohe old one.
+* Installing bottle with `pip` or similar tools will now install an additional command line executable named `bottle` into the `bin` folder of your (virtual) environment. This will replace the now deprecated `bottle.py` executable in a later release. See above.
 
 .. rubric:: Other Improvements
 

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -48,13 +48,13 @@ The easiest way to increase performance is to install a multi-threaded server li
     run(server='cheroot', ...)   # Pure Python, runs everywhere
     run(server='gunicorn', ...)  # High performance
 
-Or using the ``bottle.py`` command line interface:
+Or using the ``bottle`` command line interface:
 
 .. code-block:: sh
 
-    ./bottle.py --server gunicorn [...] mymodule:app
+    python3 -m bottle --server gunicorn [...] mymodule:app
 
-For production deployments gunicorn_ is a really good choice. It comes with its own command line utility that supports a lot more options than ``bottle.py``. Since :class:`Bottle` instances are WSGI applications, you can tell gunicorn_ (or any other WSGI server) to load your app instead of calling :func:`run` yourself:
+For production deployments gunicorn_ is a really good choice. It comes with its own command line utility that supports a lot more options than bottle. Since :class:`Bottle` instances are WSGI applications, you can tell gunicorn_ (or any other WSGI server) to load your app instead of calling :func:`run` yourself:
 
 .. code-block:: sh
 
@@ -65,7 +65,7 @@ This will start your application with 4 gunicorn workers and sane default settin
 Server adapters
 ------------------------------------------------------------------------------
 
-Bottle ships with a bunch of ready-to-use adapters for the most common WSGI servers so you can try out different server backends easily. You can select a server backend via `run(server='NAME')` or `bottle.py --server NAME`. Here is an incomplete list:
+Bottle ships with a bunch of ready-to-use adapters for the most common WSGI servers so you can try out different server backends easily. You can select a server backend via `run(server='NAME')` or `python3 -m bottle --server NAME`. Here is an incomplete list:
 
 ========  ============  ======================================================
 Name      Homepage      Description

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -30,9 +30,9 @@ It is usually a better idea to create a `virtualenv <https://docs.python.org/3/l
 
 .. code-block:: bash
 
-    $ python3 -m venv develop         # Create virtual environment
-    $ source develop/bin/activate     # Change default python to virtual one
-    (develop)$ pip install -U bottle  # Install bottle to virtual environment
+    $ python3 -m venv venv         # Create virtual environment
+    $ source venv/bin/activate     # Change default python to virtual one
+    (venv)$ pip install -U bottle  # Install bottle to virtual environment
 
 
 
@@ -60,10 +60,11 @@ The :func:`run` call in the last line starts a built-in development server. It r
 
 This is just a demonstration of the basic concept of how applications are built with Bottle. Continue reading and you'll see what else is possible.
 
+
 .. _tutorial-default:
 
 The Application Object
-------------------------------------------------------------------------------
+==============================================================================
 
 For the sake of simplicity, most examples in this tutorial use a module-level :func:`route` and other decorators to define routes. Those refer to a global "default application", an instance of :class:`Bottle` that is automatically created the first time you call :func:`route` or its friends. If you prefer a more explicit approach and don't mind the extra typing, you can create a separate application object and use that instead of the global one::
 
@@ -84,7 +85,7 @@ The object-oriented approach is further described in the :ref:`default-app` sect
 .. _tutorial-debugging:
 
 Debug Mode
---------------------------------------------------------------------------------
+==============================================================================
 
 During early development, the debug mode can be very helpful.
 
@@ -127,19 +128,33 @@ the main process. Changes in template files will not trigger a reload.
 Please use debug mode to deactivate template caching.
 
 
-Command Line Interface
-----------------------
 
-Instead of running your script directly which then calls ``bottle.run()``, you can also use ``bottle.py`` as a command line tool to load and serve your application. This is especially useful during development:
+.. _tutorial-cli:
+
+Command Line Interface
+==============================================================================
+
+Bottle is not only a module, but also a command line executable that can be used to start your app instead of calling :func:`run` programmatically. If you installed bottle via `pip` or similar tools, there will also be a handy `bottle` command on your path. Try one of the following:
 
 .. code-block:: console
 
-    $ python -m bottle --debug --reload mymodule
+    bottle --help
+    python3 -m bottle --help
+    ./path/to/bottle.py --help
+
+Here is a quick example:
+
+.. code-block:: console
+
+    $ bottle --debug --reload mymodule
     Bottle v0.13-dev server starting up (using WSGIRefServer())...
     Listening on http://localhost:8080/
     Hit Ctrl-C to quit.
 
-Call ``python3 bottle.py --help`` or ``python3 -m bottle --help`` to get a list of parameters and features.
+.. versionchanged:: 0.13
+
+    The executable script installed into (virtual) environments was named ``bottle.py``, which could result in circular imports. The old name is now deprecated and the new executable ist named just ``bottle``.
+
 
 .. _tutorial-routing:
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,11 @@ setup(name='bottle',
       },
       py_modules=['bottle'],
       scripts=['bottle.py'],
+      entry_points={
+        'console_scripts': [
+          'bottle = bottle:main',
+        ]
+      },
       license='MIT',
       platforms='any',
       classifiers=['Development Status :: 4 - Beta',


### PR DESCRIPTION
The executable script installed into (virtual) environments was named `bottle.py`, which could result in circular imports. The old name is now deprecated (but still installed) and the new executable ist named just `bottle`.