### PR TITLE
Give getattr a default value of an empty string.

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3997,7 +3997,7 @@ class FileCheckerThread(threading.Thread):
         files = dict()
 
         for module in list(sys.modules.values()):
-            path = getattr(module, '__file__') or ''
+            path = getattr(module, '__file__', '')
             if path[-4:] in ('.pyo', '.pyc'): path = path[:-1]
             if path and exists(path): files[path] = mtime(path)
 


### PR DESCRIPTION
In the case of `module` not having a `__file__` attribute, an `AttributeError` was being raised.  Using `or` here doesn't account for the attribute not existing on the object in question.

Exception in thread Thread-1:
Traceback (most recent call last):
  File "[...]/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "[...]/bottle/bottle.py", line 4000, in run
    path = getattr(module, '__file__') or ''
AttributeError: module 'sys' has no attribute '__file__'

This same exception was raised in both Python3.8 and Python3.12. To recreate this behavior, create a new project based on the hello world (OOP approach) example in the docs and include `reloader=True`.

Passing an empty string as a third argument to `getattr` should yield the desired behavior here.