### PR TITLE
Add Python 3.13 to the testing

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 5
+      max-parallel: 6
       matrix:
         python-version:
           - "3.8"
@@ -13,6 +13,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5


### PR DESCRIPTION
Related to:
* #1438
* https://www.python.org/downloads/release/python-3130/
* https://pythoninsider.blogspot.com/2024/10/python-3130-final-released.html
* https://devguide.python.org/versions/
