### PR TITLE
Update copyrights from 2024 to 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2024, Marcel Hellkamp.
+Copyright (c) 2009-2025, Marcel Hellkamp.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bottle.py
+++ b/bottle.py
@@ -9,7 +9,7 @@ Python Standard Library.
 
 Homepage and documentation: http://bottlepy.org/
 
-Copyright (c) 2009-2024, Marcel Hellkamp.
+Copyright (c) 2009-2025, Marcel Hellkamp.
 License: MIT (see LICENSE for details)
 """
 


### PR DESCRIPTION
Given commit #1473 which was made within a week ago, it is clear that defnull / Marcel Hellkamp is still involved with the Bottle project and is still making substantial edits as of 2025. Given that, I changed the copyright years in the main file and in the license to 2025.  

(This is my first pull request ever, sorry if I did something wrong.)