### PR TITLE
removed unused property

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -941,7 +941,6 @@ class Bottle(object):
             try:
                 self.trigger_hook('before_request')
                 route, args = self.router.match(environ)
-                environ['route.handle'] = route
                 environ['bottle.route'] = route
                 environ['route.url_args'] = args
                 out = route.call(**args)


### PR DESCRIPTION
environ['route.handle'] and environ['bottle.route'] store the same value, making environ['route.handle'] redundant