### PR TITLE
Fixed ResourceWarning unclosed file?

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1058,6 +1058,7 @@ class Bottle(object):
         except (KeyboardInterrupt, SystemExit, MemoryError):
             raise
         except Exception as E:
+            if hasattr(out, 'close'): out.close()
             if not self.catchall: raise
             err = '<h1>Critical error while processing request: %s</h1>' \
                   % html_escape(environ.get('PATH_INFO', '/'))


### PR DESCRIPTION
I'm running a Bottle-based web server application, which contains a route like this:

```
@bottle.get("/media.mp4")
def _get():
    return bottle.static_file("media.mp4", ".")
```

Randomly about a few times a day, a rare warning messages gets printed to the console that is running Python with Bottle and the application, something like this:

```
/home/user/website/bottle.py:1860: ResourceWarning: unclosed file <_io.BufferedReader name='/home/user/website/video.mp4'>
  ls.var = value
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

After tracing the flow of objects through a lot of code within Bottle, flup (FastCGI), and the Python standard library's WSGI, as well as implementing my own WSGI server, and also doing some stress testing on the server where I hit hard-reload on my browser many times in quick succession, I think I narrowed down the problem.

In this Bottle code, if an exception is raised during the call to `start_request()` (e.g. the underlying socket to write to has been abruptly closed by the other end), and the object returned from the application was a resource (which needs to be closed) and not simply some bytes in memory (which can be garbage-collected without drama), then Bottle leaks the resource. Relevant pieces of code:

https://github.com/bottlepy/bottle/blob/2fa7afd35feb8f4c67699b670cc45556e93f62c2/bottle.py#L1044-L1072

https://github.com/bottlepy/bottle/blob/2fa7afd35feb8f4c67699b670cc45556e93f62c2/bottle.py#L2719-L2826

My one-line patch seems to make things better when testing in production and in stress-testing, but because I'm unfamiliar with the entirety of Bottle's architecture, I am not 100% sure that this is a complete fix or the most appropriate change. Thank you for your consideration.