### PR TITLE
feat: add support for repeated query params

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -417,7 +417,7 @@ class Router:
             for i, value in enumerate(anons):
                 query['anon%d' % i] = value
             url = ''.join([f(query.pop(n)) if n else f for (n, f) in builder])
-            return url if not query else url + '?' + urlencode(query)
+            return url if not query else url + '?' + urlencode(query, doseq=True)
         except KeyError as E:
             raise RouteBuildError('Missing URL argument: %r' % E.args[0])
 


### PR DESCRIPTION
Bottle doesn't correctly support repeated query parameters.

For example:
```python
app.get_url("page", animals=["cat", "dog"])
````
Generates:
`/page?animals=%5B%27cat%27%2C+%27dog%27%5D`

Instead of the expected and standards-compliant:
`/page?animals=cat&animals=dog`

This PR adds proper support for repeated query parameters by using `urlencode(..., doseq=True)`

> When a sequence of two-element tuples is used as the query argument, the first element of each tuple is a key and the second is a value. The value element in itself can be a sequence and in that case, if the optional parameter doseq evaluates to True, individual key=value pairs separated by '&' are generated for each element of the value sequence for the key. The order of parameters in the encoded string will match the order of parameter tuples in the sequence.
>
>From [urllib docs](https://docs.python.org/3/library/urllib.parse.html)