### PR TITLE
feat: optimize `static_file()`

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -2780,7 +2780,7 @@ def static_file(filename, root,
 
     if not filename.startswith(root):
         return HTTPError(403, "Access denied.")
-    if not os.path.exists(filename) or not os.path.isfile(filename):
+    if not os.path.isfile(filename):
         return HTTPError(404, "File does not exist.")
     if not os.access(filename, os.R_OK):
         return HTTPError(403, "You do not have permission to access this file.")


### PR DESCRIPTION
I can't think of a scenario where this statement is false: `isfile(path) == True` implicates `exists(path) == True`.

I think we can remove the first check then.

https://github.com/python/cpython/blob/805e3368d6d07e58430654d1365283924fdf4143/Lib/genericpath.py#L17 and https://github.com/python/cpython/blob/805e3368d6d07e58430654d1365283924fdf4143/Lib/genericpath.py#L37 are indeed doing the same kind of calls.