### PR TITLE
add CLI route inspection that helps developers debug their applicatin…

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -42,6 +42,11 @@ def _cli_parse(args):  # pragma: no coverage
         help="override config values.")
     opt("--debug", action="store_true", help="start server in debug mode.")
     opt("--reload", action="store_true", help="auto-reload on file changes.")
+    opt("--list-routes", action="store_true",
+        help="list all routes of the application and exit.")
+    opt("--sort-routes", default="definition",
+        choices=["definition", "alphabetical"],
+        help="sort order for --list-routes (default: definition).")
     opt('app', help='WSGI app entry point.', nargs='?')
 
     cli_args = parser.parse_args(args[1:])
@@ -4521,6 +4526,47 @@ ext = _ImportRedirect('bottle.ext' if __name__ == '__main__' else
                       __name__ + ".ext", 'bottle_%s').module
 
 
+def _format_routes(app, sort="definition"):
+    """ Return a formatted table string of all routes in the application.
+
+        :param app: A :class:`Bottle` application instance.
+        :param sort: Sort order for the routes.  ``"definition"`` (default)
+            preserves the registration order, which reflects actual request
+            precedence.  ``"alphabetical"`` sorts by route rule then by HTTP
+            method, which is easier to scan in large applications or
+            documentation.
+        :return: A multi-line string ready for printing or logging.
+    """
+    rows = []
+    for route in app.routes:
+        method = route.method
+        rule = route.rule
+        callback = route.get_undecorated_callback()
+        name = getattr(callback, '__name__', '?')
+        rows.append((method, rule, name))
+
+    if not rows:
+        return "No routes found."
+
+    if sort == "alphabetical":
+        rows.sort(key=lambda r: (r[1], r[0]))
+
+    headers = ("Method", "Route", "Handler")
+    widths = [max(len(headers[i]), max(len(r[i]) for r in rows))
+              for i in range(3)]
+    fmt = "%%-%ds  %%-%ds  %%-%ds" % tuple(widths)
+    border = "-" * widths[0] + "  " + "-" * widths[1] + "  " + "-" * widths[2]
+
+    lines = [fmt % headers, border]
+    lines.extend(fmt % row for row in rows)
+    return "\n".join(lines)
+
+
+def _list_routes(app, sort="definition"):
+    """ Print the formatted route table produced by :func:`_format_routes`. """
+    print(_format_routes(app, sort=sort))
+
+
 def _main(argv):  # pragma: no coverage
     args, parser = _cli_parse(argv)
 
@@ -4537,6 +4583,11 @@ def _main(argv):  # pragma: no coverage
 
     sys.path.insert(0, '.')
     sys.modules.setdefault('bottle', sys.modules['__main__'])
+
+    if args.list_routes:
+        app = load_app(args.app)
+        _list_routes(app, sort=args.sort_routes)
+        sys.exit(0)
 
     host, port = (args.bind or 'localhost'), 8080
     if ':' in host and host.rfind(']') < host.rfind(':'):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -228,4 +228,15 @@ Misc utilities
 .. autofunction:: load
 
 .. autofunction:: load_app
-   
+
+
+Command Line Utilities
+======================
+
+The following functions support the :ref:`tutorial-cli` and can also be used
+programmatically, for example to write route tables to log files or generate
+documentation.
+
+.. autofunction:: _format_routes
+
+.. autofunction:: _list_routes

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -54,6 +54,9 @@ Release 0.14 (in development)
 .. rubric:: New features
 
 * ``bottle.HTTPError`` raised on invalid JSON now include the underlying exception in the ``exception`` field.
+* Added ``--list-routes`` command line option to print a table of all registered routes (including mounted sub-applications) and exit without starting the server.
+* Added ``--sort-routes`` command line option to control the sort order of ``--list-routes``. Accepts ``definition`` (default, matches router precedence) or ``alphabetical`` (sorted by route rule, then HTTP method).
+* Added :func:`_format_routes` to produce a formatted route table as a string, suitable for logging, file output or non-terminal environments.
 
 
 Release 0.13

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -54,6 +54,14 @@ Or using the ``bottle`` command line interface:
 
     python3 -m bottle --server gunicorn [...] mymodule:app
 
+You can verify all registered routes before starting the server with ``--list-routes``:
+
+.. code-block:: sh
+
+    python3 -m bottle --list-routes mymodule:app
+
+This prints a table of all routes (including mounted sub-applications) and exits. Add ``--sort-routes alphabetical`` to sort by route path instead of definition order. See :ref:`tutorial-cli` for details.
+
 For production deployments gunicorn_ is a really good choice. It comes with its own command line utility that supports a lot more options than bottle. Since :class:`Bottle` instances are WSGI applications, you can tell gunicorn_ (or any other WSGI server) to load your app instead of calling :func:`run` yourself:
 
 .. code-block:: sh

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -151,6 +151,41 @@ Here is a quick example:
     Listening on http://localhost:8080/
     Hit Ctrl-C to quit.
 
+Route inspection
+^^^^^^^^^^^^^^^^
+
+The ``--list-routes`` flag loads your application and prints a table of all
+registered routes (including those from mounted sub-applications), then exits
+without starting the server. This is useful for quickly verifying route
+registration or generating documentation.
+
+.. code-block:: console
+
+    $ bottle --list-routes mymodule:app
+    Method  Route           Handler
+    ------  -------------   -----------
+    GET     /hello          hello
+    POST    /users          create_user
+    GET     /sub/status     status_check
+
+By default routes are printed in **definition order**, which reflects the
+actual request-matching precedence of the router. You can switch to
+**alphabetical order** (sorted by route rule, then by HTTP method) with the
+``--sort-routes`` option:
+
+.. code-block:: console
+
+    $ bottle --list-routes --sort-routes alphabetical mymodule:app
+    Method  Route           Handler
+    ------  -------------   -----------
+    GET     /hello          hello
+    GET     /sub/status     status_check
+    POST    /users          create_user
+
+.. versionadded:: 0.14
+
+    The ``--list-routes`` and ``--sort-routes`` command line options.
+
 .. versionchanged:: 0.13
 
     The executable script installed into (virtual) environments was named ``bottle.py``, which could result in circular imports. The old name is now deprecated and the new executable ist named just ``bottle``.

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,276 @@
+# -*- coding: utf-8 -*-
+import unittest
+import sys
+from io import StringIO
+
+import bottle
+from bottle import Bottle, _cli_parse, _format_routes, _list_routes
+
+
+class TestCliParseListRoutes(unittest.TestCase):
+
+    def test_list_routes_flag_parsed(self):
+        args, _ = _cli_parse(['bottle', '--list-routes', 'app:module'])
+        self.assertTrue(args.list_routes)
+
+    def test_list_routes_flag_default_false(self):
+        args, _ = _cli_parse(['bottle', 'app:module'])
+        self.assertFalse(args.list_routes)
+
+    def test_sort_routes_default(self):
+        args, _ = _cli_parse(['bottle', 'app:module'])
+        self.assertEqual(args.sort_routes, 'definition')
+
+    def test_sort_routes_alphabetical(self):
+        args, _ = _cli_parse(['bottle', '--sort-routes', 'alphabetical',
+                              'app:module'])
+        self.assertEqual(args.sort_routes, 'alphabetical')
+
+    def test_sort_routes_definition(self):
+        args, _ = _cli_parse(['bottle', '--sort-routes', 'definition',
+                              'app:module'])
+        self.assertEqual(args.sort_routes, 'definition')
+
+    def test_sort_routes_invalid_choice(self):
+        with self.assertRaises(SystemExit):
+            _cli_parse(['bottle', '--sort-routes', 'invalid', 'app:module'])
+
+
+class TestFormatRoutes(unittest.TestCase):
+    """Tests for _format_routes — the pure, I/O-free formatter."""
+
+    def test_no_routes(self):
+        app = Bottle()
+        self.assertEqual(_format_routes(app), "No routes found.")
+
+    def test_no_routes_alphabetical(self):
+        app = Bottle()
+        self.assertEqual(_format_routes(app, sort="alphabetical"),
+                         "No routes found.")
+
+    def test_single_route(self):
+        app = Bottle()
+
+        @app.route('/hello', method='GET')
+        def hello():
+            return 'hello'
+
+        result = _format_routes(app)
+        lines = result.splitlines()
+        self.assertEqual(len(lines), 3)  # header, separator, one route
+        self.assertIn("Method", lines[0])
+        self.assertIn("Route", lines[0])
+        self.assertIn("Handler", lines[0])
+        self.assertIn("GET", lines[2])
+        self.assertIn("/hello", lines[2])
+        self.assertIn("hello", lines[2])
+
+    def test_multiple_methods(self):
+        app = Bottle()
+
+        @app.route('/item', method=['GET', 'POST'])
+        def item():
+            return 'item'
+
+        result = _format_routes(app)
+        lines = result.splitlines()
+        self.assertEqual(len(lines), 4)  # header + separator + 2 routes
+        methods = {line.split()[0] for line in lines[2:]}
+        self.assertEqual(methods, {'GET', 'POST'})
+
+    def test_definition_order_preserved(self):
+        app = Bottle()
+
+        @app.route('/b')
+        def route_b():
+            return 'b'
+
+        @app.route('/a', method='POST')
+        def route_a():
+            return 'a'
+
+        result = _format_routes(app)
+        lines = result.splitlines()
+        self.assertEqual(len(lines), 4)
+        # /b was registered first, so it stays first
+        self.assertIn("/b", lines[2])
+        self.assertIn("route_b", lines[2])
+        self.assertIn("/a", lines[3])
+        self.assertIn("route_a", lines[3])
+
+    def test_alphabetical_sort_by_rule(self):
+        app = Bottle()
+
+        @app.route('/zebra')
+        def zebra():
+            return 'z'
+
+        @app.route('/alpha')
+        def alpha():
+            return 'a'
+
+        result = _format_routes(app, sort="alphabetical")
+        lines = result.splitlines()
+        # /alpha should now come before /zebra
+        self.assertIn("/alpha", lines[2])
+        self.assertIn("/zebra", lines[3])
+
+    def test_alphabetical_sort_method_tiebreak(self):
+        app = Bottle()
+
+        @app.route('/same', method='POST')
+        def post_handler():
+            return 'post'
+
+        @app.route('/same', method='GET')
+        def get_handler():
+            return 'get'
+
+        result = _format_routes(app, sort="alphabetical")
+        lines = result.splitlines()
+        # Same rule, GET < POST alphabetically
+        self.assertIn("GET", lines[2])
+        self.assertIn("POST", lines[3])
+
+    def test_mounted_sub_app_routes(self):
+        parent = Bottle()
+        child = Bottle()
+
+        @parent.route('/parent')
+        def parent_handler():
+            return 'parent'
+
+        @child.route('/child')
+        def child_handler():
+            return 'child'
+
+        parent.mount('/sub/', child)
+
+        result = _format_routes(parent)
+        lines = result.splitlines()
+        # header + separator + parent route + child route
+        self.assertEqual(len(lines), 4)
+        texts = '\n'.join(lines[2:])
+        self.assertIn("/parent", texts)
+        self.assertIn("parent_handler", texts)
+        self.assertIn("/sub/child", texts)
+        self.assertIn("child_handler", texts)
+
+    def test_mounted_sub_app_alphabetical(self):
+        parent = Bottle()
+        child = Bottle()
+
+        @parent.route('/zzz')
+        def zzz_handler():
+            return 'zzz'
+
+        @child.route('/aaa')
+        def aaa_handler():
+            return 'aaa'
+
+        parent.mount('/sub/', child)
+
+        result = _format_routes(parent, sort="alphabetical")
+        lines = result.splitlines()
+        # /sub/aaa should sort before /zzz
+        self.assertIn("/sub/aaa", lines[2])
+        self.assertIn("/zzz", lines[3])
+
+    def test_column_alignment(self):
+        app = Bottle()
+
+        @app.route('/short')
+        def s():
+            return 's'
+
+        @app.route('/a-much-longer-route-path')
+        def longer_name():
+            return 'long'
+
+        result = _format_routes(app)
+        lines = result.splitlines()
+        # All non-separator lines should have the same length (padded)
+        header_len = len(lines[0])
+        for line in lines[2:]:
+            self.assertEqual(len(line), header_len)
+
+    def test_separator_line_uses_dashes(self):
+        app = Bottle()
+
+        @app.route('/x')
+        def x():
+            return 'x'
+
+        result = _format_routes(app)
+        lines = result.splitlines()
+        sep = lines[1]
+        self.assertTrue(all(c in ('-', ' ') for c in sep))
+
+    def test_wildcard_route(self):
+        app = Bottle()
+
+        @app.route('/user/<name>')
+        def user(name):
+            return name
+
+        result = _format_routes(app)
+        self.assertIn("/user/<name>", result)
+        self.assertIn("user", result)
+
+    def test_returns_string(self):
+        app = Bottle()
+
+        @app.route('/check')
+        def check():
+            return 'ok'
+
+        result = _format_routes(app)
+        self.assertIsInstance(result, str)
+
+
+class TestListRoutesIO(unittest.TestCase):
+    """Verify that _list_routes prints what _format_routes returns."""
+
+    def test_list_routes_prints_format_output(self):
+        app = Bottle()
+
+        @app.route('/io-test')
+        def io_test():
+            return 'io'
+
+        expected = _format_routes(app)
+
+        old = sys.stdout
+        sys.stdout = buf = StringIO()
+        try:
+            _list_routes(app)
+        finally:
+            sys.stdout = old
+
+        self.assertEqual(buf.getvalue().rstrip("\n"), expected)
+
+    def test_list_routes_passes_sort(self):
+        app = Bottle()
+
+        @app.route('/z')
+        def z():
+            return 'z'
+
+        @app.route('/a')
+        def a():
+            return 'a'
+
+        expected = _format_routes(app, sort="alphabetical")
+
+        old = sys.stdout
+        sys.stdout = buf = StringIO()
+        try:
+            _list_routes(app, sort="alphabetical")
+        finally:
+            sys.stdout = old
+
+        self.assertEqual(buf.getvalue().rstrip("\n"), expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change introduces a CLI route inspection feature that helps developers
quickly visualize the registered routes of their Bottle applications.

A new `--list-routes` flag allows developers to inspect the application routing
structure directly from the command line, simplifying debugging and improving
developer experience when working with larger applications. Routes can optionally
be sorted using `--sort-routes`.

Usage examples:

    bottle --list-routes myproject.app:app
    bottle --list-routes --sort-routes alphabetical myproject.app:app

Example application:

    # app.py
    from bottle import Bottle

    app = Bottle()

    @app.route('/')
    def index():
        return "Hello World"

    @app.route('/users')
    def users():
        return "Users"

List routes using the CLI:

    bottle --list-routes app:app

Example output:

    GET     /          index
    GET     /users     users