### PR TITLE
🤖 Keep multipart memory limit at parser default

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1367,8 +1367,7 @@ class BaseRequest:
         if not boundary:
             raise MultipartError("Invalid content type header, missing boundary")
         parser = _MultipartParser(self.body, boundary, self.content_length,
-            mem_limit=self.MEMFILE_MAX, memfile_limit=self.MEMFILE_MAX,
-            charset=charset)
+            memfile_limit=self.MEMFILE_MAX, charset=charset)
 
         for part in parser.parse():
             if not part.filename and part.is_buffered():

--- a/test/test_environ.py
+++ b/test/test_environ.py
@@ -357,6 +357,24 @@ class TestRequest(unittest.TestCase):
         self.assertEqual(['value2', '万难'], request.forms.getall('field2'))
         self.assertTrue('field2' not in request.files)
 
+    def test_multipart_large_total_payload(self):
+        """ Multipart uploads should not fail once the aggregate buffered size
+            exceeds MEMFILE_MAX, as long as individual files stay below the
+            per-file memory threshold.
+        """
+        fields = []
+        files = [
+            ('file1', 'filename1.txt', 'x' * 60000),
+            ('file2', 'filename2.txt', 'y' * 60000),
+        ]
+        e = tools.multipart_environ(fields=fields, files=files)
+        request = BaseRequest(e)
+
+        self.assertEqual('filename1.txt', request.POST['file1'].filename)
+        self.assertEqual('filename2.txt', request.POST['file2'].filename)
+        self.assertEqual('x' * 60000, request.POST['file1'].file.read().decode('utf8'))
+        self.assertEqual('y' * 60000, request.POST['file2'].file.read().decode('utf8'))
+
     def test_json_empty(self):
         """ Environ: Request.json property with empty body. """
         self.assertEqual(BaseRequest({}).json, None)


### PR DESCRIPTION
Summary:\n- keep Request.POST multipart parsing from reusing MEMFILE_MAX as the parser-wide memory limit\n- preserve MEMFILE_MAX as the per-file in-memory buffering threshold\n- add a regression test for two buffered uploads whose combined size exceeds 100KB but stays below the parser default\n\nValidation:\n- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest test/test_multipart.py test/test_environ.py -q\n- python -m py_compile bottle.py test/test_environ.py\n