### PR TITLE
[AI] Fix multipart memory limit for buffered files

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -1367,8 +1367,7 @@ class BaseRequest:
         if not boundary:
             raise MultipartError("Invalid content type header, missing boundary")
         parser = _MultipartParser(self.body, boundary, self.content_length,
-            mem_limit=self.MEMFILE_MAX, memfile_limit=self.MEMFILE_MAX,
-            charset=charset)
+            memfile_limit=self.MEMFILE_MAX, charset=charset)
 
         for part in parser.parse():
             if not part.filename and part.is_buffered():

--- a/test/test_environ.py
+++ b/test/test_environ.py
@@ -357,6 +357,24 @@ class TestRequest(unittest.TestCase):
         self.assertEqual(['value2', '万难'], request.forms.getall('field2'))
         self.assertTrue('field2' not in request.files)
 
+    def test_multipart_many_small_files_above_memfile_total(self):
+        """ Environ: POST can parse multiple files that exceed MEMFILE_MAX in total. """
+        payload = 'x' * (BaseRequest.MEMFILE_MAX // 2 + 1)
+        e = tools.multipart_environ(fields=[], files=[
+            ('file1', 'filename1.txt', payload),
+            ('file2', 'filename2.txt', payload),
+        ])
+        request = BaseRequest(e)
+        files = request.files
+
+        try:
+            self.assertEqual(tob(payload), files['file1'].file.read())
+            self.assertEqual(tob(payload), files['file2'].file.read())
+        finally:
+            files['file1'].file.close()
+            files['file2'].file.close()
+            request.body.close()
+
     def test_json_empty(self):
         """ Environ: Request.json property with empty body. """
         self.assertEqual(BaseRequest({}).json, None)


### PR DESCRIPTION
Fixes #1470.

This keeps `MEMFILE_MAX` as the per-file in-memory threshold for multipart uploads, but stops reusing that same 100 KiB value as the parser-wide total memory limit. The parser now uses its existing larger total-memory default while each individual file part still spools to disk once it exceeds `MEMFILE_MAX`.

I manually reviewed the diff and verified the regression path with:

- `python3 -m unittest test.test_environ.TestRequest.test_multipart_many_small_files_above_memfile_total`
- `python3 -m unittest test.test_environ test.test_multipart`
- `python3 -m unittest discover -t . -s test`
- `git diff --check HEAD~1..HEAD`

AI disclosure: assisted by OpenAI GPT-5. I reviewed the change and test output before submitting.

License: I explicitly license this contribution as public domain.